### PR TITLE
Add ForestryEvent.PollinateIndividual event

### DIFF
--- a/src/main/java/forestry/api/core/ForestryEvent.java
+++ b/src/main/java/forestry/api/core/ForestryEvent.java
@@ -5,13 +5,22 @@
  ******************************************************************************/
 package forestry.api.core;
 
+import javax.annotation.Nullable;
+
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 
 import com.mojang.authlib.GameProfile;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 
 import forestry.api.genetics.IBreedingTracker;
+import forestry.api.genetics.IGenome;
+import forestry.api.genetics.IIndividual;
 import forestry.api.genetics.IMutation;
 import forestry.api.genetics.ISpecies;
 import forestry.api.genetics.ISpeciesType;
@@ -55,6 +64,94 @@ public abstract class ForestryEvent extends Event {
 		public SyncedBreedingTracker(IBreedingTracker tracker, Player player) {
 			this.tracker = tracker;
 			this.player = player;
+		}
+	}
+
+	/**
+	 * Fired when a {@linkplain forestry.api.genetics.IPollinatable pollinatable}, such as leaves, is about to be
+	 * pollinated.
+	 *
+	 * <p>This event allows for mods to react to pollinations, change the genomes used for pollination, and
+	 * to cancel pollinations entirely. Event listeners that cancel a pollination should use a higher
+	 * {@linkplain EventPriority event priority} so that lower priority listeners can be aware that a pollination was
+	 * canceled before reacting to it.</p>
+	 *
+	 * <p>This event is {@linkplain Cancelable cancelable}, and does not {@linkplain HasResult have a result}.
+	 * If the event is canceled, then the individual will not be pollinated.</p>
+	 *
+	 * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus} on both the logical
+	 * client and the logical server.</p>
+	 */
+	@Cancelable
+	public static class PollinateIndividual extends ForestryEvent {
+		private final Level level;
+		private final BlockPos pos;
+		private final IIndividual individual;
+		private final IIndividual pollen;
+		@Nullable
+		private final Object pollinator;
+
+		private IGenome pollenGenome;
+
+		public PollinateIndividual(Level level, BlockPos pos, IIndividual individual, IIndividual pollen, @Nullable Object pollinator) {
+			this.level = level;
+			this.pos = pos;
+			this.individual = individual;
+			this.pollen = pollen;
+			this.pollinator = pollinator;
+			this.pollenGenome = pollen.getGenome();
+		}
+
+		/**
+		 * @return The level where the pollination will occur.
+		 */
+		public Level getLevel() {
+			return this.level;
+		}
+
+		/**
+		 * @return The position of the individual to be pollinated (ex. leaves block).
+		 */
+		public BlockPos getPos() {
+			return this.pos;
+		}
+
+		/**
+		 * @return The individual (ex. leaves block) to be pollinated.
+		 */
+		public IIndividual getIndividual() {
+			return this.individual;
+		}
+
+		/**
+		 * @return The pollen used to pollinate the individual.
+		 */
+		public IIndividual getPollen() {
+			return this.pollen;
+		}
+
+		/**
+		 * @return The individual (for bees and butterflies) or entity (for players) causing the pollination. May be {@code null}.
+		 */
+		@Nullable
+		public Object getPollinator() {
+			return this.pollinator;
+		}
+
+		/**
+		 * @return The genome to pollinate with. Starts as the genome of the pollen, but can be modified in {@link #setPollenGenome}.
+		 */
+		public IGenome getPollenGenome() {
+			return this.pollenGenome;
+		}
+
+		/**
+		 * Set the genome used to pollinate this individual.
+		 *
+		 * @param pollenGenome The genome that the individual should be pollinated with.
+		 */
+		public void setPollenGenome(IGenome pollenGenome) {
+			this.pollenGenome = pollenGenome;
 		}
 	}
 }

--- a/src/main/java/forestry/api/genetics/IPollinatable.java
+++ b/src/main/java/forestry/api/genetics/IPollinatable.java
@@ -5,17 +5,26 @@
  ******************************************************************************/
 package forestry.api.genetics;
 
+import javax.annotation.Nullable;
+
+import forestry.api.core.ForestryEvent;
+
 /**
  * Can be implemented by tile entities, if they wish to be pollinatable.
- *
- * @author SirSengir
  */
 public interface IPollinatable extends ICheckPollinatable {
-
 	/**
 	 * Pollinates this entity.
+	 * Implementations should fire the {@link ForestryEvent.PollinateIndividual} event.
 	 *
-	 * @param pollen IIndividual representing the pollen.
+	 * @param pollen IIndividual representing the pollen (the other individual to mate with).
+	 * @param pollinator The {@link IIndividual} (for bees and butterflies) or entity (for players) that is trying to
+	 *                   mate the two individuals. Can be null.
 	 */
-	void mateWith(IIndividual pollen);
+	void mateWith(IIndividual pollen, @Nullable Object pollinator);
+
+	@Deprecated
+	default void mateWith(IIndividual pollen) {
+		mateWith(pollen, null);
+	}
 }

--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -532,7 +532,7 @@ public class Bee extends IndividualLiving<IBeeSpecies, IBee, IBeeSpeciesType> im
 			IPollinatable realPollinatable = GeneticsUtil.getOrCreatePollinatable(housing.getOwner(), level, posBlock, ForestryConfig.SERVER.pollinateVanillaLeaves.get());
 
 			if (realPollinatable != null) {
-				realPollinatable.mateWith(pollen);
+				realPollinatable.mateWith(pollen, this);
 				return true;
 			}
 		}

--- a/src/main/java/forestry/arboriculture/items/ItemGermlingGE.java
+++ b/src/main/java/forestry/arboriculture/items/ItemGermlingGE.java
@@ -109,7 +109,7 @@ public class ItemGermlingGE extends ItemGE implements IVariableFermentable, ICol
 		}
 
 		if (!level.isClientSide) {
-			pollinatable.mateWith(tree);
+			pollinatable.mateWith(tree, player);
 
 			BlockUtil.sendDestroyEffects(level, pos, level.getBlockState(pos));
 

--- a/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
+++ b/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
@@ -31,6 +31,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.model.data.ModelProperty;
+import net.minecraftforge.common.MinecraftForge;
 
 import forestry.api.IForestryApi;
 import forestry.api.arboriculture.ForestryTreeSpecies;
@@ -40,6 +41,7 @@ import forestry.api.arboriculture.genetics.IFruit;
 import forestry.api.arboriculture.genetics.ITree;
 import forestry.api.client.IForestryClientApi;
 import forestry.api.climate.IBiomeProvider;
+import forestry.api.core.ForestryEvent;
 import forestry.api.core.HumidityType;
 import forestry.api.core.TemperatureType;
 import forestry.api.genetics.IEffectData;
@@ -279,14 +281,18 @@ public class TileLeaves extends TileTreeContainer implements IPollinatable, IFru
 	}
 
 	@Override
-	public void mateWith(IIndividual individual) {
-		if (individual instanceof ITree) {
+	public void mateWith(IIndividual individual, @Nullable Object pollinator) {
+		if (individual instanceof ITree mate) {
 			ITree tree = getTree();
 			if (tree == null || level == null) {
 				return;
 			}
 
-			tree.setMate(individual.getGenome());
+			ForestryEvent.PollinateIndividual event = new ForestryEvent.PollinateIndividual(this.level, this.worldPosition, tree, mate, pollinator);
+			if (MinecraftForge.EVENT_BUS.post(event)) {
+				return;
+			}
+			tree.setMate(event.getPollenGenome());
 			if (!level.isClientSide) {
 				sendNetworkUpdate();
 			}

--- a/src/main/java/forestry/lepidopterology/entities/AIButterflyPollinate.java
+++ b/src/main/java/forestry/lepidopterology/entities/AIButterflyPollinate.java
@@ -53,7 +53,7 @@ public class AIButterflyPollinate extends AIButterflyInteract {
 				} else if (checkPollinatable.canMateWith(entity.getPollen())) {
 					IPollinatable realPollinatable = GeneticsUtil.getOrCreatePollinatable(null, entity.level, rest, ForestryConfig.SERVER.pollinateVanillaLeaves.get());
 					if (realPollinatable != null) {
-						realPollinatable.mateWith(entity.getPollen());
+						realPollinatable.mateWith(entity.getPollen(), entity.getButterfly());
 						entity.setPollen(null);
 					}
 				}


### PR DESCRIPTION
Fired when a pollinatable, such as leaves, is about to be pollinated.

This event allows for mods to react to pollinations, change the genomes used for pollination, and to cancel pollinations entirely. Event listeners that cancel a pollination should use a higher event priority so that lower priority listeners can be aware that a pollination was canceled before reacting to it.

Requested by @JaisDK