### PR TITLE
Implement vanilla checks for item pickups in `PickupHandlerStorage#onItemPickup`

### DIFF
--- a/src/main/java/forestry/storage/PickupHandlerStorage.java
+++ b/src/main/java/forestry/storage/PickupHandlerStorage.java
@@ -10,6 +10,10 @@ import net.minecraft.world.item.ItemStack;
 
 public class PickupHandlerStorage {
 	public static boolean onItemPickup(Player player, ItemEntity entityitem) {
+		if (entityitem.hasPickUpDelay() || (entityitem.getTarget() != null && !entityitem.getTarget().equals(player.getUUID()))) {
+			return false;
+		}
+
 		ItemStack itemstack = entityitem.getItem();
 		if (itemstack.isEmpty()) {
 			return false;


### PR DESCRIPTION
May not be the ideal solution, as `ItemEntityPickupEvent.Post` isn't fired as in `ItemEntity#playerTouch`

Prevents dropped items from being instantly picked up by the player if the player already has at least one of that item in their inventory