### PR TITLE
JEI compatibility: draw background in IRecipeCategory#draw

### DIFF
--- a/src/main/java/forestry/arboriculture/charcoal/jei/CharcoalPileWallCategory.java
+++ b/src/main/java/forestry/arboriculture/charcoal/jei/CharcoalPileWallCategory.java
@@ -54,6 +54,7 @@ public class CharcoalPileWallCategory extends ForestryRecipeCategory<ICharcoalPi
 
 	@Override
 	public void draw(ICharcoalPileWall recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.flame.draw(graphics, 52, 0);
 		this.flameAnimated.draw(graphics, 52, 0);
 		this.arrow.draw(graphics, 50, 16);

--- a/src/main/java/forestry/core/recipes/jei/ForestryRecipeCategory.java
+++ b/src/main/java/forestry/core/recipes/jei/ForestryRecipeCategory.java
@@ -2,9 +2,10 @@ package forestry.core.recipes.jei;
 
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
-import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.category.IRecipeCategory;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 
 public abstract class ForestryRecipeCategory<T> implements IRecipeCategory<T> {
@@ -31,12 +32,9 @@ public abstract class ForestryRecipeCategory<T> implements IRecipeCategory<T> {
 		return this.background.getHeight();
 	}
 
-	// Replaces the deprecated getBackground() auto-render path: registering the
-	// background as a recipe-extras drawable lets JEI 19 paint it for us before
-	// each subclass's own draw() runs (so existing draw() overrides still work).
 	@Override
-	public void createRecipeExtras(IRecipeExtrasBuilder builder, T recipe, IFocusGroup focuses) {
-		builder.addDrawable(this.background, 0, 0);
+	public void draw(T recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+		this.background.draw(guiGraphics);
 	}
 
 	@Override

--- a/src/main/java/forestry/factory/recipes/jei/carpenter/CarpenterRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/carpenter/CarpenterRecipeCategory.java
@@ -88,6 +88,7 @@ public class CarpenterRecipeCategory extends ForestryRecipeCategory<ICarpenterRe
 
 	@Override
 	public void draw(ICarpenterRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.arrow.draw(graphics, 89, 34);
 	}
 }

--- a/src/main/java/forestry/factory/recipes/jei/centrifuge/CentrifugeRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/centrifuge/CentrifugeRecipeCategory.java
@@ -73,6 +73,7 @@ public class CentrifugeRecipeCategory extends ForestryRecipeCategory<ICentrifuge
 
 	@Override
 	public void draw(ICentrifugeRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.arrow.draw(graphics, 32, 18);
 		this.arrow.draw(graphics, 56, 18);
 	}

--- a/src/main/java/forestry/factory/recipes/jei/fermenter/FermenterRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/fermenter/FermenterRecipeCategory.java
@@ -101,6 +101,7 @@ public class FermenterRecipeCategory extends ForestryRecipeCategory<IFermenterRe
 
 	@Override
 	public void draw(IFermenterRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.progressBar0.draw(graphics, 40, 14);
 		this.progressBar1.draw(graphics, 64, 28);
 	}

--- a/src/main/java/forestry/factory/recipes/jei/moistener/MoistenerRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/moistener/MoistenerRecipeCategory.java
@@ -96,6 +96,7 @@ public class MoistenerRecipeCategory extends ForestryRecipeCategory<IMoistenerRe
 
 	@Override
 	public void draw(IMoistenerRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.arrow.draw(graphics, 78, 2);
 		this.progressBar.draw(graphics, 109, 22);
 	}

--- a/src/main/java/forestry/factory/recipes/jei/rainmaker/RainmakerRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/rainmaker/RainmakerRecipeCategory.java
@@ -50,6 +50,7 @@ public class RainmakerRecipeCategory extends ForestryRecipeCategory<RainSubstrat
 
 	@Override
 	public void draw(RainSubstrate recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		Component effect = getEffectString(recipe);
 		Component speed = Component.translatable("for.jei.rainmaker.speed", recipe.speed());
 

--- a/src/main/java/forestry/factory/recipes/jei/squeezer/SqueezerRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/squeezer/SqueezerRecipeCategory.java
@@ -73,6 +73,7 @@ public class SqueezerRecipeCategory extends ForestryRecipeCategory<ISqueezerReci
 
 	@Override
 	public void draw(ISqueezerRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.arrow.draw(graphics, 67, 25);
 	}
 }

--- a/src/main/java/forestry/factory/recipes/jei/still/StillRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/still/StillRecipeCategory.java
@@ -63,6 +63,7 @@ public class StillRecipeCategory extends ForestryRecipeCategory<IStillRecipe> {
 
 	@Override
 	public void draw(IStillRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+		super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
 		this.progressBar.draw(graphics, 50, 3);
 	}
 }

--- a/src/main/java/forestry/farming/compat/FarmingInfoRecipeCategory.java
+++ b/src/main/java/forestry/farming/compat/FarmingInfoRecipeCategory.java
@@ -97,6 +97,7 @@ public class FarmingInfoRecipeCategory extends ForestryRecipeCategory<FarmingInf
 
 	@Override
 	public void draw(FarmingInfoRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+        super.draw(recipe, recipeSlotsView, graphics, mouseX, mouseY);
         this.addition.draw(graphics, 37, 64);
         this.arrow.draw(graphics, 91, 64);
 		int recipeWidth = this.getWidth();


### PR DESCRIPTION
Fixes background being drawn *over* all other elements when using with [EMI](https://modrinth.com/mod/emi) / [TMRV](https://modrinth.com/mod/tmrv) (in lieu of proper EMI compatibility...)