### PR TITLE
Generalize centrifuge recipes to the IProduct dispatch

### DIFF
--- a/src/main/java/forestry/api/recipes/ICentrifugeRecipe.java
+++ b/src/main/java/forestry/api/recipes/ICentrifugeRecipe.java
@@ -1,6 +1,6 @@
 package forestry.api.recipes;
 
-import forestry.api.core.Product;
+import forestry.api.core.IProduct;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -35,5 +35,5 @@ public interface ICentrifugeRecipe extends IForestryRecipe {
 	 * Returns a list of all possible products and their estimated probabilities (0.0 to 1.0],
 	 * to help mods that display recipes
 	 **/
-	List<Product> getAllProducts();
+	List<IProduct> getAllProducts();
 }

--- a/src/main/java/forestry/core/data/builder/CentrifugeRecipeBuilder.java
+++ b/src/main/java/forestry/core/data/builder/CentrifugeRecipeBuilder.java
@@ -1,6 +1,7 @@
 package forestry.core.data.builder;
 
 import com.google.common.base.Preconditions;
+import forestry.api.core.IProduct;
 import forestry.api.core.Product;
 import forestry.factory.recipes.CentrifugeRecipe;
 import net.minecraft.data.recipes.RecipeOutput;
@@ -13,7 +14,7 @@ import java.util.ArrayList;
 public class CentrifugeRecipeBuilder {
 	private int processingTime;
 	private Ingredient input;
-	private final ArrayList<Product> outputs = new ArrayList<>();
+	private final ArrayList<IProduct> outputs = new ArrayList<>();
 
 	public CentrifugeRecipeBuilder setProcessingTime(int processingTime) {
 		this.processingTime = processingTime;
@@ -27,6 +28,12 @@ public class CentrifugeRecipeBuilder {
 
 	public CentrifugeRecipeBuilder product(float chance, ItemStack stack) {
 		this.outputs.add(new Product(stack.getItem(), stack.getCount(), stack.getComponentsPatch(), chance));
+		return this;
+	}
+
+	/** Adds an arbitrary {@link IProduct}, e.g. a dynamic product that resolves at runtime. */
+	public CentrifugeRecipeBuilder product(IProduct product) {
+		this.outputs.add(product);
 		return this;
 	}
 

--- a/src/main/java/forestry/factory/recipes/CentrifugeRecipe.java
+++ b/src/main/java/forestry/factory/recipes/CentrifugeRecipe.java
@@ -19,8 +19,9 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 
-import forestry.api.core.Product;
+import forestry.api.core.IProduct;
 import forestry.api.recipes.ICentrifugeRecipe;
+import forestry.core.genetics.ProductTypes;
 import forestry.factory.features.FactoryRecipeTypes;
 
 public class CentrifugeRecipe implements ICentrifugeRecipe {
@@ -28,22 +29,22 @@ public class CentrifugeRecipe implements ICentrifugeRecipe {
 		ResourceLocation.CODEC.fieldOf("id").forGetter(CentrifugeRecipe::getId),
 		Codec.INT.fieldOf("time").forGetter(CentrifugeRecipe::getProcessingTime),
 		Ingredient.CODEC_NONEMPTY.fieldOf("input").forGetter(CentrifugeRecipe::getInput),
-		Product.CODEC.listOf().fieldOf("products").forGetter(CentrifugeRecipe::getAllProducts)
+		ProductTypes.LIST_CODEC.fieldOf("products").forGetter(CentrifugeRecipe::getAllProducts)
 	).apply(instance, CentrifugeRecipe::new));
 	private static final StreamCodec<RegistryFriendlyByteBuf, CentrifugeRecipe> STREAM_CODEC = StreamCodec.composite(
 		ResourceLocation.STREAM_CODEC, CentrifugeRecipe::getId,
 		ByteBufCodecs.INT, CentrifugeRecipe::getProcessingTime,
 		Ingredient.CONTENTS_STREAM_CODEC, CentrifugeRecipe::getInput,
-		Product.STREAM_CODEC.apply(ByteBufCodecs.list()), CentrifugeRecipe::getAllProducts,
+		ProductTypes.LIST_STREAM_CODEC, CentrifugeRecipe::getAllProducts,
 		CentrifugeRecipe::new
 	);
 
 	private final ResourceLocation id;
 	private final int processingTime;
 	private final Ingredient input;
-	private final List<Product> products;
+	private final List<IProduct> products;
 
-	public CentrifugeRecipe(ResourceLocation id, int processingTime, Ingredient input, List<Product> products) {
+	public CentrifugeRecipe(ResourceLocation id, int processingTime, Ingredient input, List<IProduct> products) {
 		Preconditions.checkNotNull(id, "Recipe identifier cannot be null");
 
 		this.id = id;
@@ -66,13 +67,15 @@ public class CentrifugeRecipe implements ICentrifugeRecipe {
 	public List<ItemStack> getProducts(RandomSource random, double outputMult) {
 		ArrayList<ItemStack> products = new ArrayList<>();
 
-		for (Product entry : this.products) {
+		for (IProduct entry : this.products) {
 			double probability = entry.chance() * outputMult;
 
-			if (probability >= 1.0) {
-				products.add(entry.createStack());
-			} else if (random.nextFloat() < probability) {
-				products.add(entry.createStack());
+			if (probability >= 1.0 || random.nextFloat() < probability) {
+				// Dynamic products (e.g. a tag that no loaded mod fills) can yield an empty stack; skip those.
+				ItemStack stack = entry.createRandomStack(random);
+				if (!stack.isEmpty()) {
+					products.add(stack);
+				}
 			}
 		}
 
@@ -80,7 +83,7 @@ public class CentrifugeRecipe implements ICentrifugeRecipe {
 	}
 
 	@Override
-	public List<Product> getAllProducts() {
+	public List<IProduct> getAllProducts() {
 		return this.products;
 	}
 

--- a/src/main/java/forestry/factory/recipes/jei/centrifuge/CentrifugeRecipeCategory.java
+++ b/src/main/java/forestry/factory/recipes/jei/centrifuge/CentrifugeRecipeCategory.java
@@ -1,7 +1,7 @@
 package forestry.factory.recipes.jei.centrifuge;
 
 import forestry.api.ForestryConstants;
-import forestry.api.core.Product;
+import forestry.api.core.IProduct;
 import forestry.api.recipes.ICentrifugeRecipe;
 import forestry.core.config.Constants;
 import forestry.core.recipes.jei.ChanceTooltipCallback;
@@ -60,11 +60,11 @@ public class CentrifugeRecipeCategory extends ForestryRecipeCategory<ICentrifuge
 
 		List<IRecipeSlotBuilder> outputSlots = JeiUtil.layoutSlotGrid(builder, RecipeIngredientRole.OUTPUT, 3, 3, 101, 1, 18);
 
-		List<Product> sortedProducts = recipe.getAllProducts().stream()
-			.sorted(Comparator.comparing(Product::chance).reversed())
+		List<IProduct> sortedProducts = recipe.getAllProducts().stream()
+			.sorted(Comparator.comparing(IProduct::chance).reversed())
 			.toList();
 		for (int i = 0; i < sortedProducts.size() && i < outputSlots.size(); i++) {
-			Product product = sortedProducts.get(i);
+			IProduct product = sortedProducts.get(i);
 			outputSlots.get(i)
 				.addItemStack(product.createStack())
 				.addRichTooltipCallback(new ChanceTooltipCallback(product.chance()));

--- a/src/test/java/forestry/gametest/CentrifugeProductDispatchTest.java
+++ b/src/test/java/forestry/gametest/CentrifugeProductDispatchTest.java
@@ -1,0 +1,142 @@
+package forestry.gametest;
+
+import java.util.List;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.JsonOps;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+
+import forestry.api.ForestryConstants;
+import forestry.api.core.IProduct;
+import forestry.api.core.Product;
+import forestry.api.recipes.ICentrifugeRecipe;
+import forestry.apiculture.genetics.FireworkProduct;
+import forestry.core.features.CoreItems;
+import forestry.core.genetics.ProductTypes;
+import forestry.core.utils.RecipeUtils;
+import forestry.factory.features.FactoryRecipeTypes;
+
+/**
+ * Behavioral oracle for "centrifuge products as an IProduct dispatch". Proves that the default {@link Product}
+ * serialises byte-for-byte like the plain product codec (no {@code "type"} key) and that a dynamic product
+ * ({@link FireworkProduct}) round-trips through its own declared type, that the list stream codec round-trips a mixed
+ * list, and that the built-in centrifuge recipes still expose and resolve their products through the migrated path.
+ */
+@GameTestHolder(ForestryConstants.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class CentrifugeProductDispatchTest {
+	/** A plain Product must encode identically through the dispatch codec (no "type" key), and legacy JSON must decode. */
+	@GameTest(template = "empty")
+	public static void defaultProductMatchesPlainProductJson(GameTestHelper helper) {
+		RegistryOps<JsonElement> ops = helper.getLevel().registryAccess().createSerializationContext(JsonOps.INSTANCE);
+		Product product = Product.of(Items.SUGAR, 2, 0.9f);
+
+		JsonElement viaProduct = Product.CODEC.encodeStart(ops, product).getOrThrow();
+		JsonElement viaDispatch = ProductTypes.CODEC.encodeStart(ops, product).getOrThrow();
+		if (!viaProduct.equals(viaDispatch)) {
+			helper.fail("Default product must encode byte-for-byte like the plain product codec. plain=" + viaProduct + " dispatch=" + viaDispatch);
+			return;
+		}
+		if (viaDispatch.getAsJsonObject().has("type")) {
+			helper.fail("Default product must not write a \"type\" key: " + viaDispatch);
+			return;
+		}
+
+		// Legacy JSON (a bare product, no "type") must still decode under the dispatch codec.
+		IProduct decoded = ProductTypes.CODEC.parse(ops, viaProduct).getOrThrow();
+		if (!product.equals(decoded)) {
+			helper.fail("Legacy product JSON decoded to a different product: " + decoded);
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	/** A dynamic product must round-trip through its own declared "type" key. */
+	@GameTest(template = "empty")
+	public static void dynamicProductRoundTripsWithType(GameTestHelper helper) {
+		RegistryOps<JsonElement> ops = helper.getLevel().registryAccess().createSerializationContext(JsonOps.INSTANCE);
+		FireworkProduct firework = new FireworkProduct(0.5f);
+
+		JsonElement json = ProductTypes.CODEC.encodeStart(ops, firework).getOrThrow();
+		String type = json.getAsJsonObject().has("type") ? json.getAsJsonObject().get("type").getAsString() : null;
+		if (!ForestryConstants.forestry("firework").toString().equals(type)) {
+			helper.fail("Dynamic firework product must declare its type; got " + json);
+			return;
+		}
+
+		IProduct decoded = ProductTypes.CODEC.parse(ops, json).getOrThrow();
+		if (!(decoded instanceof FireworkProduct decodedFirework) || decodedFirework.chance() != 0.5f) {
+			helper.fail("Firework product did not round-trip through the dispatch codec: " + decoded);
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	/** The list stream codec must round-trip a mixed list of a plain and a dynamic product. */
+	@GameTest(template = "empty")
+	public static void dispatchListStreamRoundTrip(GameTestHelper helper) {
+		List<IProduct> products = List.of(Product.of(Items.SUGAR, 2, 0.9f), new FireworkProduct(0.5f));
+		RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), helper.getLevel().registryAccess());
+
+		ProductTypes.LIST_STREAM_CODEC.encode(buf, products);
+		List<IProduct> decoded = ProductTypes.LIST_STREAM_CODEC.decode(buf);
+		if (decoded.size() != 2 || !products.get(0).equals(decoded.get(0)) || !(decoded.get(1) instanceof FireworkProduct)) {
+			helper.fail("List stream codec round-trip changed the products: " + decoded);
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	/** The built-in centrifuge recipes must still expose and resolve their products through the migrated path. */
+	@GameTest(template = "empty")
+	public static void centrifugeRecipesResolveProducts(GameTestHelper helper) {
+		RecipeManager manager = helper.getLevel().getRecipeManager();
+
+		ICentrifugeRecipe honeyComb = RecipeUtils.getRecipes(manager, FactoryRecipeTypes.CENTRIFUGE)
+			.filter(recipe -> recipe.getId().equals(ForestryConstants.forestry("centrifuge/honey_comb")))
+			.findFirst()
+			.orElse(null);
+		if (honeyComb == null) {
+			helper.fail("Missing built-in centrifuge/honey_comb recipe");
+			return;
+		}
+
+		// Beeswax is a guaranteed (chance 1.0) product of the honey comb.
+		IProduct beeswax = honeyComb.getAllProducts().stream()
+			.filter(product -> product.item() == CoreItems.BEESWAX.item())
+			.findFirst()
+			.orElse(null);
+		if (beeswax == null) {
+			helper.fail("Honey comb no longer lists beeswax among its products: " + honeyComb.getAllProducts());
+			return;
+		}
+		if (beeswax.chance() != 1.0f) {
+			helper.fail("Beeswax product chance changed: " + beeswax.chance());
+			return;
+		}
+
+		// A guaranteed product must actually be produced.
+		List<ItemStack> produced = honeyComb.getProducts(RandomSource.create(0), 1.0);
+		boolean gotBeeswax = produced.stream().anyMatch(stack -> stack.is(CoreItems.BEESWAX.item()) && !stack.isEmpty());
+		if (!gotBeeswax) {
+			helper.fail("Honey comb did not produce its guaranteed beeswax output: " + produced);
+			return;
+		}
+
+		helper.succeed();
+	}
+}


### PR DESCRIPTION
Centrifuge recipes stored their products as concrete `Product`s, while every other product list in the codebase (bee/tree/butterfly species) already goes through the `IProduct` dispatch codec in `ProductTypes` (which supports dynamic products such as `FireworkProduct`). Bring centrifuge in line:

- `CentrifugeRecipe` now holds `List<IProduct>` and (de)serializes via `ProductTypes.LIST_CODEC` / `LIST_STREAM_CODEC`. The dispatch treats a plain item as the default type and omits the `type` key, so existing recipe JSON and network packets are byte-identical (verified: runData produces no diff under src/generated).
- `getProducts` now calls `IProduct#createRandomStack` (a plain `Product` delegates to `createStack`, so behaviour is unchanged) and skips empty stacks, so a dynamic product that resolves to nothing at runtime is simply omitted from the output.
- `ICentrifugeRecipe#getAllProducts` returns `List<IProduct>`; the JEI category and the datagen builder follow. The builder keeps its `product(float, ItemStack)` helper and gains a `product(IProduct)` overload for dynamic products.