### PR TITLE
Generalize squeezer fluid output to a fluid ingredient

### DIFF
--- a/src/generated/resources/data/forestry/recipe/squeezer/cactus.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/cactus.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/cactus",
   "output": {
     "amount": 500,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/cherry.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/cherry.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/cherry",
   "output": {
     "amount": 50,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/chestnut.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/chestnut.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/chestnut",
   "output": {
     "amount": 80,
-    "id": "forestry:seed_oil"
+    "fluid": "forestry:seed_oil"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/coconut.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/coconut.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/coconut",
   "output": {
     "amount": 500,
-    "id": "minecraft:milk"
+    "fluid": "minecraft:milk"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/dates.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/dates.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/dates",
   "output": {
     "amount": 50,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/feijoa.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/feijoa.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/feijoa",
   "output": {
     "amount": 100,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/lemon.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/lemon.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/lemon",
   "output": {
     "amount": 400,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/olive.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/olive.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/olive",
   "output": {
     "amount": 100,
-    "id": "forestry:seed_oil"
+    "fluid": "forestry:seed_oil"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/orange.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/orange.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/orange",
   "output": {
     "amount": 400,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/papaya.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/papaya.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/papaya",
   "output": {
     "amount": 600,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/pear.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/pear.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/pear",
   "output": {
     "amount": 100,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/plum.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/plum.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/plum",
   "output": {
     "amount": 100,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/fruit/walnut.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/fruit/walnut.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/fruit/walnut",
   "output": {
     "amount": 50,
-    "id": "forestry:seed_oil"
+    "fluid": "forestry:seed_oil"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/honey_block.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/honey_block.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/honey_block",
   "output": {
     "amount": 800,
-    "id": "forestry:honey"
+    "fluid": "forestry:honey"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/honey_dew.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/honey_dew.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/honey_dew",
   "output": {
     "amount": 100,
-    "id": "forestry:honey"
+    "fluid": "forestry:honey"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/honey_drop.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/honey_drop.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/honey_drop",
   "output": {
     "amount": 100,
-    "id": "forestry:honey"
+    "fluid": "forestry:honey"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/ice.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/ice.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/ice",
   "output": {
     "amount": 4000,
-    "id": "forestry:crushed_ice"
+    "fluid": "forestry:crushed_ice"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/lava.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/lava.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/lava",
   "output": {
     "amount": 500,
-    "id": "minecraft:lava"
+    "fluid": "minecraft:lava"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/lava_magma.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/lava_magma.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/lava_magma",
   "output": {
     "amount": 1000,
-    "id": "minecraft:lava"
+    "fluid": "minecraft:lava"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/lava_sand.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/lava_sand.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/lava_sand",
   "output": {
     "amount": 500,
-    "id": "minecraft:lava"
+    "fluid": "minecraft:lava"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/mulch.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/mulch.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/mulch",
   "output": {
     "amount": 200,
-    "id": "forestry:fruit_juice"
+    "fluid": "forestry:fruit_juice"
   },
   "remnant": {
     "count": 1,

--- a/src/generated/resources/data/forestry/recipe/squeezer/seeds.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/seeds.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/seeds",
   "output": {
     "amount": 10,
-    "id": "forestry:seed_oil"
+    "fluid": "forestry:seed_oil"
   },
   "resources": [
     {

--- a/src/generated/resources/data/forestry/recipe/squeezer/sponge_comb.json
+++ b/src/generated/resources/data/forestry/recipe/squeezer/sponge_comb.json
@@ -4,7 +4,7 @@
   "id": "forestry:squeezer/sponge_comb",
   "output": {
     "amount": 100,
-    "id": "forestry:honey"
+    "fluid": "forestry:honey"
   },
   "remnant": {
     "count": 1,

--- a/src/main/java/forestry/core/data/builder/SqueezerRecipeBuilder.java
+++ b/src/main/java/forestry/core/data/builder/SqueezerRecipeBuilder.java
@@ -6,13 +6,14 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import java.util.List;
 
 public class SqueezerRecipeBuilder {
 	private int processingTime;
 	private List<Ingredient> resources;
-	private FluidStack fluidOutput;
+	private SizedFluidIngredient fluidOutput;
 	private ItemStack remnants = ItemStack.EMPTY;
 	private float remnantsChance;
 
@@ -27,6 +28,12 @@ public class SqueezerRecipeBuilder {
 	}
 
 	public SqueezerRecipeBuilder setFluidOutput(FluidStack fluidOutput) {
+		this.fluidOutput = SizedFluidIngredient.of(fluidOutput);
+		return this;
+	}
+
+	/** Sets a fluid ingredient output, e.g. a fluid tag resolved at runtime to whatever a loaded mod fills. */
+	public SqueezerRecipeBuilder setFluidOutput(SizedFluidIngredient fluidOutput) {
 		this.fluidOutput = fluidOutput;
 		return this;
 	}

--- a/src/main/java/forestry/factory/recipes/SqueezerRecipe.java
+++ b/src/main/java/forestry/factory/recipes/SqueezerRecipe.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import java.util.List;
 
@@ -24,7 +25,9 @@ public class SqueezerRecipe implements ISqueezerRecipe {
 		ResourceLocation.CODEC.fieldOf("id").forGetter(SqueezerRecipe::getId),
 		Codec.INT.fieldOf("time").forGetter(SqueezerRecipe::getProcessingTime),
 		Ingredient.CODEC_NONEMPTY.listOf().fieldOf("resources").forGetter(SqueezerRecipe::getInputs),
-		FluidStack.CODEC.fieldOf("output").forGetter(SqueezerRecipe::getFluidOutput),
+		// A fluid ingredient, not a fixed FluidStack: a fluid tag resolves at runtime to whatever fluid a loaded
+		// mod fills (e.g. some other mod's molten iron), so a recipe isn't tied to one mod's fluid.
+		SizedFluidIngredient.FLAT_CODEC.fieldOf("output").forGetter(SqueezerRecipe::getFluidOutputIngredient),
 		// "remnant" is optional: many squeezer recipes drop no remnant.
 		// ItemStack.STRICT_CODEC rejects EMPTY at serialization, so map EMPTY to absent.
 		ItemStack.STRICT_CODEC.optionalFieldOf("remnant").forGetter(r -> r.remnants.isEmpty() ? java.util.Optional.<ItemStack>empty() : java.util.Optional.of(r.remnants)),
@@ -38,11 +41,11 @@ public class SqueezerRecipe implements ISqueezerRecipe {
 	private final ResourceLocation id;
 	private final int processingTime;
 	private final List<Ingredient> resources;
-	private final FluidStack fluidOutput;
+	private final SizedFluidIngredient fluidOutput;
 	private final ItemStack remnants;
 	private final float remnantsChance;
 
-	public SqueezerRecipe(ResourceLocation id, int processingTime, List<Ingredient> resources, FluidStack fluidOutput, ItemStack remnants, float remnantsChance) {
+	public SqueezerRecipe(ResourceLocation id, int processingTime, List<Ingredient> resources, SizedFluidIngredient fluidOutput, ItemStack remnants, float remnantsChance) {
 		Preconditions.checkNotNull(id, "Recipe identifier cannot be null");
 		Preconditions.checkNotNull(resources);
 		Preconditions.checkArgument(!resources.isEmpty());
@@ -74,6 +77,14 @@ public class SqueezerRecipe implements ISqueezerRecipe {
 
 	@Override
 	public FluidStack getFluidOutput() {
+		// Resolve the ingredient to a concrete fluid: take the first matching stack (its amount already applied).
+		// An unfulfilled tag matches nothing, so we return EMPTY and TileSqueezer refuses the recipe.
+		FluidStack[] fluids = this.fluidOutput.getFluids();
+		return fluids.length == 0 ? FluidStack.EMPTY : fluids[0].copy();
+	}
+
+	/** The output as a fluid ingredient, for serialization. Consumers wanting the actual fluid use {@link #getFluidOutput()}. */
+	public SizedFluidIngredient getFluidOutputIngredient() {
 		return this.fluidOutput;
 	}
 
@@ -117,7 +128,7 @@ public class SqueezerRecipe implements ISqueezerRecipe {
 			ResourceLocation recipeId = ResourceLocation.STREAM_CODEC.decode(buffer);
 			int processingTime = ByteBufCodecs.VAR_INT.decode(buffer);
 			List<Ingredient> resources = Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()).decode(buffer);
-			FluidStack fluidOutput = FluidStack.STREAM_CODEC.decode(buffer);
+			SizedFluidIngredient fluidOutput = SizedFluidIngredient.STREAM_CODEC.decode(buffer);
 			ItemStack remnants = ItemStack.OPTIONAL_STREAM_CODEC.decode(buffer);
 			float remnantsChance = ByteBufCodecs.FLOAT.decode(buffer);
 
@@ -128,7 +139,7 @@ public class SqueezerRecipe implements ISqueezerRecipe {
 			ResourceLocation.STREAM_CODEC.encode(buffer, recipe.id);
 			ByteBufCodecs.VAR_INT.encode(buffer, recipe.processingTime);
 			Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()).encode(buffer, recipe.resources);
-			FluidStack.STREAM_CODEC.encode(buffer, recipe.fluidOutput);
+			SizedFluidIngredient.STREAM_CODEC.encode(buffer, recipe.fluidOutput);
 			ItemStack.OPTIONAL_STREAM_CODEC.encode(buffer, recipe.remnants);
 			ByteBufCodecs.FLOAT.encode(buffer, recipe.remnantsChance);
 		}

--- a/src/main/java/forestry/factory/tiles/TileSqueezer.java
+++ b/src/main/java/forestry/factory/tiles/TileSqueezer.java
@@ -176,6 +176,12 @@ public class TileSqueezer extends TilePowered implements ISocketable, WorldlyCon
 					}
 				}
 			}
+
+			// A dynamic output (e.g. a fluid tag no loaded mod fills) resolves to empty; refuse the recipe rather
+			// than consuming the input for no fluid.
+			if (matchingRecipe != null && matchingRecipe.getFluidOutput().isEmpty()) {
+				matchingRecipe = null;
+			}
 		}
 
 		if (this.currentRecipe != matchingRecipe) {

--- a/src/test/java/forestry/gametest/SqueezerFluidOutputTest.java
+++ b/src/test/java/forestry/gametest/SqueezerFluidOutputTest.java
@@ -1,0 +1,153 @@
+package forestry.gametest;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.JsonOps;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+
+import forestry.api.ForestryConstants;
+import forestry.api.recipes.ISqueezerRecipe;
+import forestry.core.config.Constants;
+import forestry.core.fluids.ForestryFluids;
+import forestry.core.utils.RecipeUtils;
+import forestry.factory.features.FactoryRecipeTypes;
+import forestry.factory.recipes.SqueezerRecipe;
+
+/**
+ * Behavioral oracle for "squeezer fluid output as a {@link SizedFluidIngredient}". Proves that a plain fluid output
+ * serialises to the flat {@code {"fluid", "amount"}} form and round-trips (JSON and network), that a fluid tag resolves
+ * at runtime to whatever fluid a loaded mod fills (an unfulfilled tag resolving to {@link FluidStack#EMPTY}), and that
+ * the built-in squeezer recipes still resolve to their concrete fluid output through the migrated code path.
+ */
+@GameTestHolder(ForestryConstants.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class SqueezerFluidOutputTest {
+	/** A plain fluid output encodes to the flat fluid-ingredient JSON ({@code fluid}/{@code amount}) and round-trips. */
+	@GameTest(template = "empty")
+	public static void plainOutputRoundTripsThroughFlatJson(GameTestHelper helper) {
+		RegistryOps<JsonElement> ops = helper.getLevel().registryAccess().createSerializationContext(JsonOps.INSTANCE);
+		FluidStack stack = ForestryFluids.HONEY.getFluid(500);
+
+		JsonElement json = SizedFluidIngredient.FLAT_CODEC.encodeStart(ops, SizedFluidIngredient.of(stack)).getOrThrow();
+		JsonObject obj = json.getAsJsonObject();
+		if (!obj.has("fluid") || !obj.has("amount")) {
+			helper.fail("A plain fluid output should encode with \"fluid\" and \"amount\" keys: " + json);
+			return;
+		}
+
+		SizedFluidIngredient decoded = SizedFluidIngredient.FLAT_CODEC.parse(ops, json).getOrThrow();
+		if (!sameFluid(first(decoded), stack)) {
+			helper.fail("Flat JSON round-trip changed the output: " + first(decoded));
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	/** The fluid-ingredient stream codec must round-trip the output unchanged. */
+	@GameTest(template = "empty")
+	public static void streamRoundTrip(GameTestHelper helper) {
+		FluidStack stack = ForestryFluids.HONEY.getFluid(800);
+		RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), helper.getLevel().registryAccess());
+
+		SizedFluidIngredient.STREAM_CODEC.encode(buf, SizedFluidIngredient.of(stack));
+		SizedFluidIngredient decoded = SizedFluidIngredient.STREAM_CODEC.decode(buf);
+		if (!sameFluid(first(decoded), stack)) {
+			helper.fail("Stream codec round-trip changed the output: " + first(decoded));
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	/**
+	 * A tag output resolves to whatever fluid the tag holds (the mod-agnostic case the ingredient enables), and an
+	 * unfulfilled tag resolves to {@link FluidStack#EMPTY} so {@code TileSqueezer} can refuse the recipe.
+	 */
+	@GameTest(template = "empty")
+	public static void tagOutputResolvesAndEmptyTagYieldsEmpty(GameTestHelper helper) {
+		// A populated vanilla tag: water resolves to a concrete fluid, amount applied.
+		SqueezerRecipe waterRecipe = recipeWithOutput(new SizedFluidIngredient(
+			net.neoforged.neoforge.fluids.crafting.FluidIngredient.tag(FluidTags.WATER), 500));
+		FluidStack resolved = waterRecipe.getFluidOutput();
+		if (resolved.isEmpty() || resolved.getAmount() != 500) {
+			helper.fail("A populated fluid tag should resolve to a concrete fluid x500, got: " + resolved);
+			return;
+		}
+
+		// A tag no fluid fills resolves to empty (rather than throwing or fabricating a fluid).
+		TagKey<Fluid> missing = TagKey.create(Registries.FLUID, ForestryConstants.forestry("gametest_no_such_fluid"));
+		SqueezerRecipe missingRecipe = recipeWithOutput(new SizedFluidIngredient(
+			net.neoforged.neoforge.fluids.crafting.FluidIngredient.tag(missing), 500));
+		if (!missingRecipe.getFluidOutput().isEmpty()) {
+			helper.fail("An unfulfilled fluid tag should resolve to EMPTY, got: " + missingRecipe.getFluidOutput());
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	/** Every built-in squeezer recipe must resolve to a non-empty fluid, and honey_block must resolve to honey x800. */
+	@GameTest(template = "empty")
+	public static void squeezerRecipesResolveOutput(GameTestHelper helper) {
+		RecipeManager manager = helper.getLevel().getRecipeManager();
+
+		long count = RecipeUtils.getRecipes(manager, FactoryRecipeTypes.SQUEEZER).count();
+		if (count == 0) {
+			helper.fail("No squeezer recipes loaded");
+			return;
+		}
+		boolean anyEmpty = RecipeUtils.getRecipes(manager, FactoryRecipeTypes.SQUEEZER)
+			.anyMatch(recipe -> recipe.getFluidOutput().isEmpty());
+		if (anyEmpty) {
+			helper.fail("A built-in squeezer recipe resolved to an empty fluid output");
+			return;
+		}
+
+		ISqueezerRecipe honeyBlock = RecipeUtils.getRecipes(manager, FactoryRecipeTypes.SQUEEZER)
+			.filter(recipe -> recipe.getId().equals(ForestryConstants.forestry("squeezer/honey_block")))
+			.findFirst()
+			.orElse(null);
+		if (honeyBlock == null) {
+			helper.fail("Missing built-in squeezer/honey_block recipe");
+			return;
+		}
+		FluidStack expected = ForestryFluids.HONEY.getFluid(Constants.FLUID_PER_HONEY_DROP * 8);
+		if (!sameFluid(honeyBlock.getFluidOutput(), expected)) {
+			helper.fail("honey_block output changed: " + honeyBlock.getFluidOutput() + ", expected " + expected);
+			return;
+		}
+
+		helper.succeed();
+	}
+
+	private static SqueezerRecipe recipeWithOutput(SizedFluidIngredient output) {
+		return new SqueezerRecipe(
+			ForestryConstants.forestry("gametest/dynamic_output"), 20,
+			java.util.List.of(net.minecraft.world.item.crafting.Ingredient.of(net.minecraft.world.item.Items.STONE)),
+			output, net.minecraft.world.item.ItemStack.EMPTY, 0.0f);
+	}
+
+	private static FluidStack first(SizedFluidIngredient ingredient) {
+		FluidStack[] fluids = ingredient.getFluids();
+		return fluids.length == 0 ? FluidStack.EMPTY : fluids[0];
+	}
+
+	private static boolean sameFluid(FluidStack a, FluidStack b) {
+		return FluidStack.isSameFluidSameComponents(a, b) && a.getAmount() == b.getAmount();
+	}
+}


### PR DESCRIPTION
Squeezer recipes stored their output as a concrete FluidStack, which ties a recipe to one
mod's fluid. Store the output as a NeoForge SizedFluidIngredient instead: a fluid ingredient
can be a tag, which resolves at runtime to whatever fluid a loaded mod fills so a recipe
isn't hard-coded to a single fluid.

- SqueezerRecipe holds a SizedFluidIngredient; getFluidOutput() resolves it via getFluids()[0]
  (the first matching stack, amount already applied). An unfulfilled tag matches nothing and
  resolves to FluidStack.EMPTY.
- (De)serialization uses SizedFluidIngredient.FLAT_CODEC (JSON) and STREAM_CODEC (network); the
  network now carries the ingredient rather than a pre-resolved stack.
- TileSqueezer still refuses a recipe whose output resolves empty, so a dynamic output no loaded
  mod can satisfy doesn't consume the input for nothing.
- The datagen builder keeps setFluidOutput(FluidStack) and gains a setFluidOutput(SizedFluidIngredient).
- Recipe JSON output changes only its key: "id" -> "fluid" (the flat fluid-ingredient form),
  regenerated via runData. No recipe uses fluid components, so nothing else moves.
- SqueezerFluidOutputTest covers the flat-JSON and stream round-trips, tag resolution (a populated
  vanilla tag resolves to a concrete fluid; an unfulfilled tag resolves to EMPTY), and resolution
  of the built-in squeezer recipes.