### PR TITLE
Naturalist chest: stop page flips from warping the mouse cursor

### DIFF
--- a/src/main/java/forestry/core/tiles/TileNaturalistChest.java
+++ b/src/main/java/forestry/core/tiles/TileNaturalistChest.java
@@ -133,5 +133,14 @@ public abstract class TileNaturalistChest extends TileBase implements IPagedInve
 		public AbstractContainerMenu createMenu(int windowId, Inventory playerInv, Player player) {
 			return new ContainerNaturalistInventory(windowId, playerInv, TileNaturalistChest.this, this.page, this.isFlipPage);
 		}
+
+		@Override
+		public boolean shouldTriggerClientSideContainerClosingOnOpen() {
+			// Flipping a page reopens this menu server-side. The default (true) sends the client a
+			// container-close packet first, which momentarily returns it to the in-game GUI and grabs
+			// the mouse - warping the cursor to the window centre. Returning false skips that close so
+			// the new page swaps in without moving the cursor.
+			return !this.isFlipPage;
+		}
 	}
 }


### PR DESCRIPTION
Flipping a page in an apiarist/arborist/lepidopterist chest reopens the menu server-side via player.openMenu. Because a menu is already open, vanilla sends the client a container-close packet first, which runs setScreen(null) -> grabs the mouse and re-centres the OS cursor before the new page's open packet arrives.

Override MenuProvider#shouldTriggerClientSideContainerClosingOnOpen to return false for page flips so openMenu uses the server-only doCloseContainer path, skipping the client close and leaving the cursor where it was.