### PR TITLE
Extend capabilities of creative frames for testing

### DIFF
--- a/src/main/java/forestry/api/apiculture/IBeeModifier.java
+++ b/src/main/java/forestry/api/apiculture/IBeeModifier.java
@@ -113,4 +113,21 @@ public interface IBeeModifier {
 	default boolean isHellish() {
 		return false;
 	}
+
+	/**
+	 * @return Whether this hive provides its bees' required flowers on its own, so the queen can work even when no
+	 * matching flowers exist nearby. Used by the creative frame to make an apiary function in any environment.
+	 */
+	default boolean providesFlowers() {
+		return false;
+	}
+
+	/**
+	 * @return Whether this hive fully satisfies its bees' temperature and humidity requirements regardless of the actual
+	 * climate, so the queen never suffers a too-cold/too-hot/too-arid/too-humid error. Used by the creative frame to make
+	 * an apiary function in any biome.
+	 */
+	default boolean isClimateFullyTolerant() {
+		return false;
+	}
 }

--- a/src/main/java/forestry/apiculture/BeeHousingModifier.java
+++ b/src/main/java/forestry/apiculture/BeeHousingModifier.java
@@ -103,4 +103,24 @@ public class BeeHousingModifier implements IBeeModifier {
 		}
 		return false;
 	}
+
+	@Override
+	public boolean providesFlowers() {
+		for (IBeeModifier modifier : this.beeHousing.getBeeModifiers()) {
+			if (modifier.providesFlowers()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isClimateFullyTolerant() {
+		for (IBeeModifier modifier : this.beeHousing.getBeeModifiers()) {
+			if (modifier.isClimateFullyTolerant()) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/src/main/java/forestry/apiculture/BeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/BeekeepingLogic.java
@@ -213,7 +213,7 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 		// might be worth only running this check in absence of other errors
 		this.hasFlowersCache.update(this.queen, this.housing);
 
-		boolean hasFlowers = this.hasFlowersCache.hasFlowers();
+		boolean hasFlowers = this.beeModifier.providesFlowers() || this.hasFlowersCache.hasFlowers();
 		boolean flowerCacheNeedsSync = this.hasFlowersCache.needsSync();
 		errorLogic.setCondition(!hasFlowers, ForestryError.NO_FLOWER);
 

--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -196,30 +196,32 @@ public class Bee extends IndividualLiving<IBeeSpecies, IBee, IBeeSpeciesType> im
 			}
 		}
 
-		// And finally climate check
+		// And finally climate check, unless the housing fully tolerates any climate (e.g. a creative frame).
 		IBeeSpecies species = this.species;
 
-		TemperatureType actualTemperature = housing.temperature();
-		TemperatureType beeBaseTemperature = species.getTemperature();
-		ToleranceType beeToleranceTemperature = this.genome.getActiveValue(BeeChromosomes.TEMPERATURE_TOLERANCE);
+		if (!beeModifier.isClimateFullyTolerant()) {
+			TemperatureType actualTemperature = housing.temperature();
+			TemperatureType beeBaseTemperature = species.getTemperature();
+			ToleranceType beeToleranceTemperature = this.genome.getActiveValue(BeeChromosomes.TEMPERATURE_TOLERANCE);
 
-		if (!ClimateHelper.isWithinLimits(actualTemperature, beeBaseTemperature, beeToleranceTemperature)) {
-			if (beeBaseTemperature.ordinal() > actualTemperature.ordinal()) {
-				errorStates.add(ForestryError.TOO_COLD);
-			} else {
-				errorStates.add(ForestryError.TOO_HOT);
+			if (!ClimateHelper.isWithinLimits(actualTemperature, beeBaseTemperature, beeToleranceTemperature)) {
+				if (beeBaseTemperature.ordinal() > actualTemperature.ordinal()) {
+					errorStates.add(ForestryError.TOO_COLD);
+				} else {
+					errorStates.add(ForestryError.TOO_HOT);
+				}
 			}
-		}
 
-		HumidityType actualHumidity = housing.humidity();
-		HumidityType beeBaseHumidity = species.getHumidity();
-		ToleranceType beeToleranceHumidity = this.genome.getActiveValue(BeeChromosomes.HUMIDITY_TOLERANCE);
+			HumidityType actualHumidity = housing.humidity();
+			HumidityType beeBaseHumidity = species.getHumidity();
+			ToleranceType beeToleranceHumidity = this.genome.getActiveValue(BeeChromosomes.HUMIDITY_TOLERANCE);
 
-		if (!ClimateHelper.isWithinLimits(actualHumidity, beeBaseHumidity, beeToleranceHumidity)) {
-			if (beeBaseHumidity.ordinal() > actualHumidity.ordinal()) {
-				errorStates.add(ForestryError.TOO_ARID);
-			} else {
-				errorStates.add(ForestryError.TOO_HUMID);
+			if (!ClimateHelper.isWithinLimits(actualHumidity, beeBaseHumidity, beeToleranceHumidity)) {
+				if (beeBaseHumidity.ordinal() > actualHumidity.ordinal()) {
+					errorStates.add(ForestryError.TOO_ARID);
+				} else {
+					errorStates.add(ForestryError.TOO_HUMID);
+				}
 			}
 		}
 

--- a/src/main/java/forestry/apiculture/items/ItemCreativeHiveFrame.java
+++ b/src/main/java/forestry/apiculture/items/ItemCreativeHiveFrame.java
@@ -113,5 +113,15 @@ public class ItemCreativeHiveFrame extends ItemForestry implements IHiveFrame {
 		public boolean isHellish() {
 			return true;
 		}
+
+		@Override
+		public boolean providesFlowers() {
+			return true;
+		}
+
+		@Override
+		public boolean isClimateFullyTolerant() {
+			return true;
+		}
 	}
 }

--- a/src/main/java/forestry/apiculture/items/ItemCreativeHiveFrame.java
+++ b/src/main/java/forestry/apiculture/items/ItemCreativeHiveFrame.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Rarity;
@@ -26,6 +28,13 @@ import org.jetbrains.annotations.Nullable;
 // 100% mutation chance. 100% production chance. 0% lifespan.
 public class ItemCreativeHiveFrame extends ItemForestry implements IHiveFrame {
 	public static final String NBT_FORCE_MUTATIONS = "force_mutations";
+	/**
+	 * When present, the id of the single mutation <em>result species</em> this frame forces. Unlike
+	 * {@link #NBT_FORCE_MUTATIONS} (which forces a random one of the pair's mutations to 100%), this makes only the
+	 * mutation producing that species eligible, so breeding a parent pair with several possible results is deterministic.
+	 * The mutation's own conditions (temperature/biome/…) still apply.
+	 */
+	public static final String NBT_FORCED_MUTATION = "forced_mutation";
 
 	public ItemCreativeHiveFrame() {
 		super(new Item.Properties().rarity(Rarity.EPIC));
@@ -43,7 +52,10 @@ public class ItemCreativeHiveFrame extends ItemForestry implements IHiveFrame {
 		tooltip.add(Component.translatable("item.forestry.bee.modifier.production", Modifier.PRODUCTION));
 		tooltip.add(Component.translatable("item.forestry.bee.modifier.genetic.decay", Modifier.GENETIC_DECAY));
 
-		if (hasForceMutations(stack)) {
+		ResourceLocation forced = getForcedMutation(stack);
+		if (forced != null) {
+			tooltip.add(Component.literal("Forces mutation: " + forced).withStyle(ChatFormatting.LIGHT_PURPLE));
+		} else if (hasForceMutations(stack)) {
 			tooltip.add(Component.literal("Maximum mutation chances").withStyle(ChatFormatting.LIGHT_PURPLE));
 		} else {
 			tooltip.add(Component.literal("Base mutation chances").withStyle(ChatFormatting.GRAY));
@@ -52,7 +64,11 @@ public class ItemCreativeHiveFrame extends ItemForestry implements IHiveFrame {
 
 	@Override
 	public IBeeModifier getBeeModifier(ItemStack frame) {
-		return hasForceMutations(frame) ? Modifier.FORCE_MUTATIONS : Modifier.BASE_MUTATIONS;
+		ResourceLocation forced = getForcedMutation(frame);
+		if (forced != null) {
+			return new Modifier(forced);
+		}
+		return hasForceMutations(frame) ? Modifier.FORCE_ANY : Modifier.BASE;
 	}
 
 	public static boolean hasForceMutations(ItemStack stack) {
@@ -60,19 +76,53 @@ public class ItemCreativeHiveFrame extends ItemForestry implements IHiveFrame {
 		return customData != null && customData.contains(NBT_FORCE_MUTATIONS);
 	}
 
-	private enum Modifier implements IBeeModifier {
-		BASE_MUTATIONS,
-		FORCE_MUTATIONS {
-			@Override
-			public float modifyMutationChance(IGenome genome, IGenome mate, IMutation<IBeeSpecies> mutation, float currentChance) {
-				return MUTATION;
-			}
-		};
+	/** @return the result-species id this frame forces (see {@link #NBT_FORCED_MUTATION}), or {@code null} if none. */
+	@Nullable
+	public static ResourceLocation getForcedMutation(ItemStack stack) {
+		CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+		if (customData == null || !customData.contains(NBT_FORCED_MUTATION)) {
+			return null;
+		}
+		return ResourceLocation.tryParse(customData.copyTag().getString(NBT_FORCED_MUTATION));
+	}
 
-		private static final float PRODUCTION = 10000f;
-		private static final float POLLINATION = 100f;
-		private static final float MUTATION = 100f;
-		private static final float GENETIC_DECAY = 0f;
+	/** Writes the forced result species onto the frame (see {@link #NBT_FORCED_MUTATION}). */
+	public static void setForcedMutation(ItemStack stack, ResourceLocation result) {
+		CompoundTag tag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
+		tag.putString(NBT_FORCED_MUTATION, result.toString());
+		stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+	}
+
+	/**
+	 * The creative frame's bee modifier. Always applies the creative perks (max production, instant aging, sealed/always
+	 * active, etc.); its mutation behaviour depends on {@link #forcedResult}:
+	 * <ul>
+	 *     <li>{@code null} + {@code !forceAny}: base mutation chance (a plain creative frame).</li>
+	 *     <li>{@code null} + {@code forceAny}: forces a random one of the pair's mutations to 100%.</li>
+	 *     <li>non-null: forces <em>only</em> the mutation producing that species (others get 0), so selection is
+	 *     deterministic for a multi-result pair.</li>
+	 * </ul>
+	 */
+	private record Modifier(boolean forceAny, @Nullable ResourceLocation forcedResult) implements IBeeModifier {
+		static final float PRODUCTION = 10000f;
+		static final float POLLINATION = 100f;
+		static final float MUTATION = 100f;
+		static final float GENETIC_DECAY = 0f;
+
+		static final Modifier BASE = new Modifier(false, null);
+		static final Modifier FORCE_ANY = new Modifier(true, null);
+
+		Modifier(ResourceLocation forcedResult) {
+			this(true, forcedResult);
+		}
+
+		@Override
+		public float modifyMutationChance(IGenome genome, IGenome mate, IMutation<IBeeSpecies> mutation, float currentChance) {
+			if (this.forcedResult != null) {
+				return mutation.getResult().id().equals(this.forcedResult) ? MUTATION : 0f;
+			}
+			return this.forceAny ? MUTATION : currentChance;
+		}
 
 		@Override
 		public float modifyAging(IGenome genome, @Nullable IGenome mate, float currentAging) {


### PR DESCRIPTION
For testing beegistics I needed an easy way of forcing mutations in the default test biome (used by gameTestServer), these base changes helped that quite a bit. The first would impact existing creative frame, just expanding what stuff they skip in the checks. The second for nbt forcing mutations is only really usable from test code or explicit nbt editing.