### PR TITLE
Multiblock: let addons contribute alveary/farm components again

### DIFF
--- a/src/main/java/forestry/core/multiblock/LevelStructureView.java
+++ b/src/main/java/forestry/core/multiblock/LevelStructureView.java
@@ -1,5 +1,7 @@
 package forestry.core.multiblock;
 
+import forestry.api.multiblock.IAlvearyComponent;
+import forestry.api.multiblock.IFarmComponent;
 import forestry.apiculture.features.ApicultureTiles;
 import forestry.apiculture.multiblock.AlvearyPattern;
 import forestry.core.multiblock.pattern.StructurePos;
@@ -7,6 +9,8 @@ import forestry.core.multiblock.pattern.StructureView;
 import forestry.farming.features.FarmingTiles;
 import forestry.farming.multiblock.FarmPattern;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -33,8 +37,9 @@ import java.util.Map;
  * {@code "alveary_plain"}), and every farm member registers without the {@code "farm_"} prefix
  * ({@code "plain"}, {@code "gearbox"}, …). {@link #typeIdFor} therefore maps each member
  * {@link BlockEntityType} to the pattern type-id via an explicit table built from the feature holders
- * ({@code ApicultureTiles}/{@code FarmingTiles}). A BE whose type is not a known multiblock member maps
- * to {@code null} (the cell is reported as not-a-component → {@code invalid.interior}).
+ * ({@code ApicultureTiles}/{@code FarmingTiles}), or, for an addon block implementing {@link IAlvearyComponent} /
+ * {@link IFarmComponent}, a generated prefixed id (see {@link #addonComponentTypeId}). A BE that is neither maps to
+ * {@code null} (the cell is reported as not-a-component → {@code invalid.interior}).
  */
 public final class LevelStructureView implements StructureView {
 	private final Level level;
@@ -62,7 +67,7 @@ public final class LevelStructureView implements StructureView {
 		// Component: resolve via the BlockEntity's type. getBlockEntity is safe here because validation
 		// only samples cells it has already confirmed loaded (loaded-shell rule).
 		BlockEntity be = this.level.getBlockEntity(blockPos);
-		String componentTypeId = be == null ? null : typeIdFor(be.getType());
+		String componentTypeId = be == null ? null : typeIdFor(be);
 		boolean isComponent = componentTypeId != null;
 
 		BlockState state = this.level.getBlockState(blockPos);
@@ -83,13 +88,31 @@ public final class LevelStructureView implements StructureView {
 	private static volatile Map<BlockEntityType<?>, String> typeIds;
 
 	@Nullable
-	private static String typeIdFor(BlockEntityType<?> type) {
+	public static String typeIdFor(BlockEntity be) {
 		Map<BlockEntityType<?>, String> map = typeIds;
 		if (map == null) {
 			map = buildTypeIds();
 			typeIds = map;
 		}
-		return map.get(type);
+		String mapped = map.get(be.getType());
+		if (mapped != null) {
+			return mapped;
+		}
+		// Addon components are recognised by implementing the public IAlvearyComponent / IFarmComponent interface.
+		if (be instanceof IAlvearyComponent<?>) {
+			return addonComponentTypeId(be, AlvearyPattern.PREFIX);
+		}
+		if (be instanceof IFarmComponent<?>) {
+			return addonComponentTypeId(be, FarmPattern.PREFIX);
+		}
+		return null;
+	}
+
+	/** @return a machine-prefixed type id for an addon component, unique per block-entity type (never a reserved {@code *_plain}/{@code *_gearbox} role). */
+	public static String addonComponentTypeId(BlockEntity be, String machinePrefix) {
+		ResourceLocation key = BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(be.getType());
+		String suffix = key == null ? "addon" : key.getNamespace() + "_" + key.getPath();
+		return machinePrefix + suffix;
 	}
 
 	private static synchronized Map<BlockEntityType<?>, String> buildTypeIds() {

--- a/src/test/java/forestry/gametest/LevelStructureViewComponentTest.java
+++ b/src/test/java/forestry/gametest/LevelStructureViewComponentTest.java
@@ -1,0 +1,131 @@
+package forestry.gametest;
+
+import javax.annotation.Nullable;
+
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+
+import forestry.api.ForestryConstants;
+import forestry.api.multiblock.IAlvearyComponent;
+import forestry.api.multiblock.IFarmComponent;
+import forestry.api.multiblock.IMultiblockController;
+import forestry.api.multiblock.IMultiblockLogicAlveary;
+import forestry.api.multiblock.IMultiblockLogicFarm;
+import forestry.apiculture.multiblock.AlvearyPattern;
+import forestry.core.multiblock.LevelStructureView;
+import forestry.farming.multiblock.FarmPattern;
+
+/**
+ * Covers the addon-component fallback in {@link LevelStructureView#typeIdFor}: a block entity implementing
+ * {@link IAlvearyComponent} / {@link IFarmComponent} maps to a prefixed type id that is never a reserved
+ * {@code *_plain} / {@code *_gearbox} role, while a BE implementing neither stays a non-component.
+ */
+@GameTestHolder(ForestryConstants.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class LevelStructureViewComponentTest {
+	private static final BlockState ANY_STATE = Blocks.FURNACE.defaultBlockState();
+
+	@GameTest(template = "empty")
+	public static void addonAlvearyComponentIsRecognised(GameTestHelper helper) {
+		String id = LevelStructureView.typeIdFor(new FakeAlvearyPart());
+		helper.assertTrue(id != null && id.startsWith(AlvearyPattern.PREFIX),
+				"an addon IAlvearyComponent must map to an alveary_ type id, got " + id);
+		helper.assertTrue(!AlvearyPattern.PLAIN.equals(id),
+				"an addon component must not usurp the reserved plain interior/top role");
+		helper.succeed();
+	}
+
+	@GameTest(template = "empty")
+	public static void addonFarmComponentIsRecognised(GameTestHelper helper) {
+		String id = LevelStructureView.typeIdFor(new FakeFarmPart());
+		helper.assertTrue(id != null && id.startsWith(FarmPattern.PREFIX),
+				"an addon IFarmComponent must map to a farm_ type id, got " + id);
+		helper.assertTrue(!FarmPattern.PLAIN.equals(id) && !FarmPattern.GEARBOX.equals(id),
+				"an addon component must not usurp a reserved farm role (plain/gearbox)");
+		helper.succeed();
+	}
+
+	@GameTest(template = "empty")
+	public static void nonComponentBlockEntityMapsToNull(GameTestHelper helper) {
+		helper.assertTrue(LevelStructureView.typeIdFor(new FakeInert()) == null,
+				"a BE implementing no multiblock-part interface must not be treated as a component");
+		helper.succeed();
+	}
+
+	// --- fakes: real BlockEntities whose type (furnace) is absent from the member map, so they exercise the fallback ---
+
+	private static class FakeInert extends BlockEntity {
+		FakeInert() {
+			super(BlockEntityType.FURNACE, BlockPos.ZERO, ANY_STATE);
+		}
+	}
+
+	private static class FakeAlvearyPart extends BlockEntity implements IAlvearyComponent<IMultiblockLogicAlveary> {
+		FakeAlvearyPart() {
+			super(BlockEntityType.FURNACE, BlockPos.ZERO, ANY_STATE);
+		}
+
+		@Override
+		public BlockPos getCoordinates() {
+			return getBlockPos();
+		}
+
+		@Nullable
+		@Override
+		public GameProfile getOwner() {
+			return null;
+		}
+
+		@Override
+		public IMultiblockLogicAlveary getMultiblockLogic() {
+			return null;
+		}
+
+		@Override
+		public void onMachineAssembled(IMultiblockController controller, BlockPos min, BlockPos max) {
+		}
+
+		@Override
+		public void onMachineBroken() {
+		}
+	}
+
+	private static class FakeFarmPart extends BlockEntity implements IFarmComponent<IMultiblockLogicFarm> {
+		FakeFarmPart() {
+			super(BlockEntityType.FURNACE, BlockPos.ZERO, ANY_STATE);
+		}
+
+		@Override
+		public BlockPos getCoordinates() {
+			return getBlockPos();
+		}
+
+		@Nullable
+		@Override
+		public GameProfile getOwner() {
+			return null;
+		}
+
+		@Override
+		public IMultiblockLogicFarm getMultiblockLogic() {
+			return null;
+		}
+
+		@Override
+		public void onMachineAssembled(IMultiblockController controller, BlockPos min, BlockPos max) {
+		}
+
+		@Override
+		public void onMachineBroken() {
+		}
+	}
+}


### PR DESCRIPTION
The multiblock rewrite recognised components via a fixed BlockEntityType->type-id map in LevelStructureView, so a third-party block could never be an alveary/farm part. Restore the pre-rewrite behaviour: on a map miss, fall back to a generated prefixed type id when the block entity implements IAlvearyComponent/IFarmComponent (never a reserved *_plain/*_gearbox role, so addon parts stay in the exterior band). AlvearyController already buckets members by these interfaces, so recognition was the only gate.

Adds LevelStructureViewComponentTest covering the fallback.