### PR TITLE
Fix artifactId assignment in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -362,7 +362,7 @@ publishing {
 		publications {
 			mavenJava(MavenPublication) {
 				groupId = project.group
-				artifactId = project.base.archivesName
+				artifactId = project.base.archivesName.get()
 				version = project.version
 
 				// ForgeGradle will generate wild dependency definitions, see https://github.com/MinecraftForge/ForgeGradle/issues/584


### PR DESCRIPTION
we passed Gradles archivesName provider where maven expected a plain string so Gradle serialized the provider object into a invalid artifactId instead of using its value.

Fixes:
```
> Task :publishMavenJavaPublicationToMavenLocal FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
   > Invalid publication 'mavenJava': artifactId (extension 'base' property 'archivesName') is not a valid Maven identifier ([A-Za-z0-9_\-.]+).

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 22s
13 actionable tasks: 11 executed, 2 from cache
```