### PR TITLE
Replace HashMap with ConcurrentHashMap for thread safety

### DIFF
--- a/src/main/java/forestry/core/multiblock/MultiblockIndex.java
+++ b/src/main/java/forestry/core/multiblock/MultiblockIndex.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A per-{@link Level} map of active multiblock machines, keyed by the holder (anchor) {@link BlockPos}
@@ -18,17 +19,21 @@ import java.util.Map;
  * purely a lookup so a member BE can resolve its controller from its stored {@code anchorPos} (Task 2.4),
  * and the event-driven triggers (Task 2.5) can register and deregister a controller as it (de)assembles.
  *
- * <p><b>Threading.</b> Chunk load and unload and the BE lifecycle run on the main server thread in 1.20.1
- * (spec constraint), so this uses plain {@link HashMap}s with no synchronization. All access is on the
- * main thread. There is one inner map per {@code Level}. Server and client levels are distinct keys, so
- * the client's own validation and ticking is naturally separated (spec 9).
+ * <p><b>Threading.</b> Each individual level's block entity lifecycle normally runs on that level's
+ * owning thread, so the per-level controller maps remain plain {@link HashMap}s. The outer level map is
+ * shared by the integrated server and client, however, and those sides can register their distinct
+ * {@link Level} instances concurrently. It therefore uses a {@link ConcurrentHashMap} so
+ * {@link Map#computeIfAbsent(Object, java.util.function.Function)} is safe across client and server
+ * level loading. Server and client levels remain distinct keys, preserving side separation (spec 9).
  *
  * <p>This class is intentionally inert in Task 2.1. Nothing populates or consults it yet. It is wired in
  * by the controller and BE rework (Tasks 2.4 and 2.5).
  */
 public final class MultiblockIndex {
-	// Level -> (holderPos -> controller), keyed by Level identity since server and client levels differ
-	private static final Map<LevelAccessor, Map<BlockPos, MultiblockController>> LEVELS = new HashMap<>();
+	// Level -> (holderPos -> controller), keyed by Level identity since server and client levels differ.
+	// The outer map must be concurrent because integrated client and server levels can load in parallel.
+	private static final Map<LevelAccessor, Map<BlockPos, MultiblockController>> LEVELS =
+			new ConcurrentHashMap<>();
 
 	private MultiblockIndex() {
 	}
@@ -57,7 +62,7 @@ public final class MultiblockIndex {
 		}
 		MultiblockController removed = map.remove(holderPos.immutable());
 		if (map.isEmpty()) {
-			LEVELS.remove(level);
+			LEVELS.remove(level, map);
 		}
 		return removed;
 	}
@@ -72,7 +77,7 @@ public final class MultiblockIndex {
 		return map == null ? null : map.get(holderPos.immutable());
 	}
 
-	/** All active controllers in the given level, as an unmodifiable snapshot view. */
+	/** All active controllers in the given level, as an unmodifiable view. */
 	public static Collection<MultiblockController> getControllers(Level level) {
 		Map<BlockPos, MultiblockController> map = LEVELS.get(level);
 		return map == null ? Collections.emptyList() : Collections.unmodifiableCollection(map.values());


### PR DESCRIPTION
I didn't check, maybe WeakHashMap would be better. This works though.

Fixes a crash I encountered:

<details>

<summary>Click for stacktrace</summary>

```text
---- Minecraft Crash Report ----
// I let you down. Sorry :(

Time: 2026-07-29 01:01:26
Description: Unexpected error

java.util.ConcurrentModificationException: null
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1229) ~[?:?] {re:mixin}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockIndex.mapFor(MultiblockIndex.java:37) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockIndex.register(MultiblockIndex.java:45) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockValidation.assemble(MultiblockValidation.java:253) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockValidation.validateFor(MultiblockValidation.java:77) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockTileEntityForestry.onLoad(MultiblockTileEntityForestry.java:205) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.lambda$tickBlockEntities$0(Level.java:581) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:flywheel.impl.mixins.json:LevelMixin from mod flywheel,pl:mixin:APP:kubejs.mixins.json:LevelMixin from mod kubejs,pl:mixin:A}
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?] {}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.tickBlockEntities(Level.java:577) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:flywheel.impl.mixins.json:LevelMixin from mod flywheel,pl:mixin:APP:kubejs.mixins.json:LevelMixin from mod kubejs,pl:mixin:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.multiplayer.ClientLevel.tickEntities(ClientLevel.java:288) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:architectury.mixins.json:MixinClientLevel from mod architectury,pl:mixin:APP:kubejs.mixins.json:ClientLevelMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.tick(Minecraft.java:1868) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:kubejs.mixins.json:MinecraftClientMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.runTick(Minecraft.java:1167) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:kubejs.mixins.json:MinecraftClientMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.run(Minecraft.java:813) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:kubejs.mixins.json:MinecraftClientMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.main.Main.main(Main.java:230) ~[neoforge-21.1.230.jar%23189!/:?] {re:classloading,pl:runtimedistcleaner:A}
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?] {}
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:136) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:124) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.NeoForgeClientDevLaunchHandler.runService(NeoForgeClientDevLaunchHandler.java:23) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:118) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.run(Launcher.java:103) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.main(Launcher.java:74) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-11.0.5.jar%23128!/:?] {}
        at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210) [bootstraplauncher-2.0.2.jar:?] {}
        at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69) [bootstraplauncher-2.0.2.jar:?] {}
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?] {}
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?] {}
        at net.neoforged.devlaunch.Main.main(Main.java:57) [DevLaunch-1.0.2.jar:?] {}


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Render thread
Stacktrace:
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1229) ~[?:?] {re:mixin}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockIndex.mapFor(MultiblockIndex.java:37) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockIndex.register(MultiblockIndex.java:45) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockValidation.assemble(MultiblockValidation.java:253) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockValidation.validateFor(MultiblockValidation.java:77) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/forestry@3.0.0-alpha1/forestry.core.multiblock.MultiblockTileEntityForestry.onLoad(MultiblockTileEntityForestry.java:205) ~[forestry-1.21.1-3.0.0-alpha1.jar%23193!/:3.0.0-alpha1] {re:classloading}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.lambda$tickBlockEntities$0(Level.java:581) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:flywheel.impl.mixins.json:LevelMixin from mod flywheel,pl:mixin:APP:kubejs.mixins.json:LevelMixin from mod kubejs,pl:mixin:A}
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?] {}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.tickBlockEntities(Level.java:577) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:flywheel.impl.mixins.json:LevelMixin from mod flywheel,pl:mixin:APP:kubejs.mixins.json:LevelMixin from mod kubejs,pl:mixin:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.multiplayer.ClientLevel.tickEntities(ClientLevel.java:288) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:architectury.mixins.json:MixinClientLevel from mod architectury,pl:mixin:APP:kubejs.mixins.json:ClientLevelMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
-- Uptime --
Details:
        JVM uptime: 141.944s
        Wall uptime: 129.789s
        High-res time: 140.037s
        Client ticks: 2371 ticks / 118.550s
Stacktrace:
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.fillReport(Minecraft.java:2410) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:kubejs.mixins.json:MinecraftClientMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.emergencySaveAndCrash(Minecraft.java:874) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:kubejs.mixins.json:MinecraftClientMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.run(Minecraft.java:834) ~[neoforge-21.1.230.jar%23189!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:kubejs.mixins.json:MinecraftClientMixin from mod kubejs,pl:mixin:A,pl:runtimedistcleaner:A}
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.main.Main.main(Main.java:230) ~[neoforge-21.1.230.jar%23189!/:?] {re:classloading,pl:runtimedistcleaner:A}
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?] {}
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:136) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:124) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.NeoForgeClientDevLaunchHandler.runService(NeoForgeClientDevLaunchHandler.java:23) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:118) ~[loader-4.0.42.jar%23146!/:4.0] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.run(Launcher.java:103) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.main(Launcher.java:74) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-11.0.5.jar%23128!/:?] {}
        at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-11.0.5.jar%23128!/:?] {}
        at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210) [bootstraplauncher-2.0.2.jar:?] {}
        at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69) [bootstraplauncher-2.0.2.jar:?] {}
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?] {}
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?] {}
        at net.neoforged.devlaunch.Main.main(Main.java:57) [DevLaunch-1.0.2.jar:?] {}


-- Affected level --
Details:
        All players: 1 total; [LocalPlayer['Dev'/1, l='ClientLevel', x=2.58, y=56.00, z=-27.93]]
        Chunk stats: 961, 609
        Level dimension: minecraft:overworld
        Level spawn location: World: (0,56,0), Section: (at 0,8,0 in 0,3,0; chunk contains blocks 0,-64,0 to 15,319,15), Region: (0,0; contains chunks 0,0 to 31,31, blocks 0,-64,0 to 511,319,511)
        Level time: 320661 game time, 1122 day time
        Server brand: neoforge
        Server type: Integrated singleplayer server
        Tracked entity count: 1

-- Last reload --
Details:
        Reload number: 1
        Reload reason: initial
        Finished: Yes
        Packs: vanilla, KubeJS Virtual Resource Pack [Before Mods, assets], mod_resources, mod/rhino, mod/jade, mod/architectury, mod/jei, mod/mekanism,mekanismadditions,mekanismgenerators,mekanismtools, mod/flywheel, mod/ponder, mod/curios, mod/patchouli, mod/forestry, mod/binniecore,binniedesign,botany,extrabees,extratrees,genetics, mod/neoforge, mod/kubejs, KubeJS Virtual Resource Pack [Internal, assets], KubeJS Virtual Resource Pack [After Mods, assets], KubeJS File Resource Pack [assets], mod/betteradvancedtooltips, KubeJS Virtual Resource Pack [Last, assets]

-- System Details --
Details:
        Minecraft Version: 1.21.1
        Minecraft Version ID: 1.21.1
        Operating System: Windows 11 (amd64) version 10.0
        Java Version: 21.0.11, Azul Systems, Inc.
        Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Azul Systems, Inc.
        Memory: 444704480 bytes (424 MiB) / 1543503872 bytes (1472 MiB) up to 16953376768 bytes (16168 MiB)
        CPUs: 32
        Processor Vendor: AuthenticAMD
        Processor Name: AMD Ryzen 9 7950X3D 16-Core Processor
        Identifier: AuthenticAMD Family 25 Model 97 Stepping 2
        Microarchitecture: Zen 3
        Frequency (GHz): 4.20
        Number of physical packages: 1
        Number of physical CPUs: 16
        Number of logical CPUs: 32
        Graphics card #0 name: NVIDIA GeForce RTX 4090
        Graphics card #0 vendor: NVIDIA
        Graphics card #0 VRAM (MiB): 24564.00
        Graphics card #0 deviceId: VideoController1
        Graphics card #0 versionInfo: 32.0.16.1062
        Graphics card #1 name: AMD Radeon(TM) Graphics
        Graphics card #1 vendor: Advanced Micro Devices, Inc.
        Graphics card #1 VRAM (MiB): 512.00
        Graphics card #1 deviceId: VideoController2
        Graphics card #1 versionInfo: 32.0.21043.5001
        Memory slot #0 capacity (MiB): 32768.00
        Memory slot #0 clockSpeed (GHz): 4.80
        Memory slot #0 type: Unknown
        Memory slot #1 capacity (MiB): 32768.00
        Memory slot #1 clockSpeed (GHz): 4.80
        Memory slot #1 type: Unknown
        Virtual memory max (MiB): 91287.92
        Virtual memory used (MiB): 41278.29
        Swap memory total (MiB): 26624.00
        Swap memory used (MiB): 148.19
        Space in storage for jna.tmpdir (MiB): <path not set>
        Space in storage for org.lwjgl.system.SharedLibraryExtractPath (MiB): <path not set>
        Space in storage for io.netty.native.workdir (MiB): <path not set>
        Space in storage for java.io.tmpdir (MiB): available: 217102.52, total: 952832.00
        Space in storage for workdir (MiB): available: 53560.51, total: 476923.00
        JVM Flags: 2 total; -XX:+AllowEnhancedClassRedefinition -XX:+IgnoreUnrecognizedVMOptions
        Launched Version: 21.1.230
        Backend library: LWJGL version 3.3.3+5
        Backend API: NVIDIA GeForce RTX 4090/PCIe/SSE2 GL version 4.6.0 NVIDIA 610.62, NVIDIA Corporation
        Window size: 2560x1369
        GFLW Platform: win32
        GL Caps: Using framebuffer using OpenGL 3.2
        GL debug messages:
        Is Modded: Definitely; Client brand changed to 'neoforge'; Server brand changed to 'neoforge'
        Universe: 400921fb54442d18
        Type: Integrated Server (map_client.txt)
        Graphics mode: fancy
        Render Distance: 12/12 chunks
        Resource Packs: vanilla, mod_resources, mod/rhino, mod/jade (incompatible), mod/architectury (incompatible), mod/jei (incompatible), mod/mekanism,mekanismadditions,mekanismgenerators,mekanismtools, mod/flywheel, mod/ponder (incompatible), mod/curios (incompatible), mod/patchouli (incompatible), mod/forestry (incompatible), mod/binniecore,binniedesign,botany,extrabees,extratrees,genetics, mod/neoforge, mod/kubejs, mod/betteradvancedtooltips
        Current Language: en_us
        Locale: en_GB
        System encoding: Cp1252
        File encoding: UTF-8
        CPU: 32x AMD Ryzen 9 7950X3D 16-Core Processor
        Server Running: true
        Player Count: 1 / 8; [ServerPlayer['Dev'/1, l='ServerLevel[New World]', x=2.58, y=56.00, z=-27.93]]
        Active Data Packs: vanilla, mod_data, mod/rhino, mod/jade (incompatible), mod/architectury (incompatible), mod/jei (incompatible), mod/mekanism,mekanismadditions,mekanismgenerators,mekanismtools, mod/flywheel (incompatible), mod/ponder (incompatible), mod/curios (incompatible), mod/patchouli (incompatible), mod/forestry (incompatible), mod/binniecore,binniedesign,botany,extrabees,extratrees,genetics, mod/neoforge, mod/kubejs, mod/betteradvancedtooltips
        Available Data Packs: bundle, trade_rebalance, vanilla, mod/architectury (incompatible), mod/betteradvancedtooltips, mod/binniecore,binniedesign,botany,extrabees,extratrees,genetics, mod/curios (incompatible), mod/flywheel (incompatible), mod/forestry (incompatible), mod/jade (incompatible), mod/jei (incompatible), mod/kubejs, mod/mekanism,mekanismadditions,mekanismgenerators,mekanismtools, mod/neoforge, mod/patchouli (incompatible), mod/ponder (incompatible), mod/rhino, mod_data
        Enabled Feature Flags: minecraft:vanilla
        World Generation: Stable
        World Seed: 4385809163805108427
        ModLauncher: 11.0.5+main.901c6ea8
        ModLauncher launch target: forgeclientdev
        ModLauncher services:
                sponge-mixin-0.15.2+mixin.0.8.7.jar mixin PLUGINSERVICE
                loader-4.0.42.jar slf4jfixer PLUGINSERVICE
                loader-4.0.42.jar runtime_enum_extender PLUGINSERVICE
                at-modlauncher-10.0.1.jar accesstransformer PLUGINSERVICE
                loader-4.0.42.jar runtimedistcleaner PLUGINSERVICE
                modlauncher-11.0.5.jar mixin TRANSFORMATIONSERVICE
                modlauncher-11.0.5.jar fml TRANSFORMATIONSERVICE
        FML Language Providers:
                javafml@4.0
                lowcodefml@4.0
                minecraft@4.0
        Mod List:
                architectury-neoforge-13.0.8.jar                  |Architectury                  |architectury                  |13.0.8              |Manifest: NOSIGNATURE
                better-advanced-tooltips-2101.1.0-build.1.jar     |Better Advanced Tooltips      |betteradvancedtooltips        |2101.1.0-build.1    |Manifest: NOSIGNATURE
                main                                              |Binnie's Core                 |binniecore                    |3.0.0-alpha.0       |Manifest: NOSIGNATURE
                curios-neoforge-9.5.1+1.21.1.jar                  |Curios API                    |curios                        |9.5.1+1.21.1        |Manifest: NOSIGNATURE
                flywheel-neoforge-1.21.1-1.0.4.jar                |Flywheel                      |flywheel                      |1.0.4               |Manifest: NOSIGNATURE
                forestry-1.21.1-3.0.0-alpha1.jar                  |Forestry                      |forestry                      |3.0.0-alpha1        |Manifest: NOSIGNATURE
                jade-324717-5427817.jar                           |Jade                          |jade                          |15.0.4+neoforge     |Manifest: NOSIGNATURE
                jei-1.21.1-neoforge-19.27.0.340.jar               |Just Enough Items             |jei                           |19.27.0.340         |Manifest: NOSIGNATURE
                kubejs-neoforge-2101.7.2-build.368.jar            |KubeJS                        |kubejs                        |2101.7.2-build.368  |Manifest: NOSIGNATURE
                Mekanism-1.21.1-10.7.14.79-all.jar                |Mekanism                      |mekanism                      |10.7.14             |Manifest: NOSIGNATURE
                neoforge-21.1.230.jar                             |Minecraft                     |minecraft                     |1.21.1              |Manifest: NOSIGNATURE
                neoforge-21.1.230.jar                             |NeoForge                      |neoforge                      |21.1.230            |Manifest: NOSIGNATURE
                Patchouli-1.21.1-93-NEOFORGE.jar                  |Patchouli                     |patchouli                     |1.21.1-93-NEOFORGE  |Manifest: NOSIGNATURE
                ponder-neoforge-1.0.87+mc1.21.1.jar               |Ponder                        |ponder                        |1.0.87+mc1.21.1     |Manifest: NOSIGNATURE
                rhino-2101.2.7-build.81.jar                       |Rhino                         |rhino                         |2101.2.7-build.81   |Manifest: NOSIGNATURE
        Crash Report UUID: f7749c8c-7443-4dde-95da-c4a5c5000117
        FML: 4.0.42
        NeoForge: 21.1.230
        Flywheel Backend: flywheel:indirect
[01:01:26] [Render thread/FATAL] [ne.ne.ne.co.NeoForgeMod/]: Preparing crash report with UUID cec8fcca-5c87-42d9-9ceb-deb034f5d842
```

</details>