### PR TITLE
restore pickup animation and sound for topped-off stacks

### DIFF
--- a/src/main/java/forestry/storage/ModuleStorage.java
+++ b/src/main/java/forestry/storage/ModuleStorage.java
@@ -54,7 +54,11 @@ public class ModuleStorage extends BlankForestryModule {
 	}
 
 	private static void onItemPickup(ItemEntityPickupEvent.Pre event) {
+		int pickupCount = event.getItemEntity().getItem().getCount();
+
 		if (PickupHandlerStorage.onItemPickup(event.getPlayer(), event.getItemEntity())) {
+			event.getPlayer().take(event.getItemEntity(), pickupCount);
+			event.getItemEntity().discard();
 			event.setCanPickup(net.neoforged.neoforge.common.util.TriState.FALSE);
 		}
 	}


### PR DESCRIPTION
Forestry’s storage pickup handler tops off matching stacks in the player inventory before vanilla processes the item pickup.

When the existing inventory stack can accept the entire dropped stack, Forestry empties the ItemEntity and denies further vanilla pickup handling. This bypasses the vanilla Player.take() call responsible for sending the pickup animation and sound notification to clients.

Preserve the original dropped stack count and explicitly call Player.take() when Forestry fully consumes the ItemEntity. The consumed entity is then discarded before vanilla pickup handling is denied.

This restores the normal pickup animation and sound without changing inventory insertion behavior or causing vanilla to process the item a second time.