### PR TITLE
fix(farming): modernize chorus harvesting and clean up remaining stems

### DIFF
--- a/src/farms/java/forestry/agriculture/farmlogic/FarmLogicEnder.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/FarmLogicEnder.java
@@ -78,7 +78,9 @@ public class FarmLogicEnder extends FarmLogicHomogeneous {
 				canHarvest &= harvestBlock(world, pos.relative(facing), facing.getOpposite(), plants, flowers);
 			}
 			if (canHarvest) {
-				plants.addFirst(new CropDestroy(world, Blocks.CHORUS_PLANT.defaultBlockState(), pos, null));
+				// Keep the stem's current state for effects and drop handling.
+				// Chorus plant connection properties differ from the default state.
+				plants.addFirst(new CropDestroy(world, blockState, pos, null));
 			}
 			return canHarvest;
 		}

--- a/src/farms/java/forestry/agriculture/farmlogic/crops/CropChorusFlower.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/crops/CropChorusFlower.java
@@ -2,12 +2,15 @@ package forestry.agriculture.farmlogic.crops;
 
 import forestry.core.platform.util.BlockUtil;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.NonNullList;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.CommonHooks;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CropChorusFlower extends Crop {
@@ -24,16 +27,28 @@ public class CropChorusFlower extends Crop {
 
 	@Override
 	protected List<ItemStack> harvestBlock(Level level, BlockPos pos) {
-		NonNullList<ItemStack> harvested = NonNullList.create();
-		harvested.add(new ItemStack(Blocks.CHORUS_FLOWER));
-		//TODO: Fix dropping
-		//float chance = ForgeEventFactory.fireBlockHarvesting(harvested, level, pos, BLOCK_STATE, 0, 1.0F, false, null);
-		float chance = 1.0F;
-		harvested.removeIf(next -> level.random.nextFloat() > chance);
+		if (level instanceof ServerLevel serverLevel) {
+			CommonHooks.handleBlockDrops(
+				serverLevel,
+				pos,
+				BLOCK_STATE,
+				level.getBlockEntity(pos),
+				new ArrayList<>(List.of(new ItemEntity(
+					level,
+					// We could use pos.getCenter(), but let's avoid importing Vec3 for this.
+					pos.getX() + 0.5D,
+					pos.getY() + 0.5D,
+					pos.getZ() + 0.5D,
+					new ItemStack(Blocks.CHORUS_FLOWER)
+				))),
+				null,
+				ItemStack.EMPTY
+			);
+		}
 
 		BlockUtil.sendDestroyEffects(level, pos, BLOCK_STATE);
 		level.removeBlock(pos, false);
 
-		return harvested;
+		return List.of();
 	}
 }

--- a/src/farms/java/forestry/agriculture/farmlogic/crops/CropDestroy.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/crops/CropDestroy.java
@@ -33,7 +33,9 @@ public class CropDestroy extends Crop {
 
 	@Override
 	protected boolean isCrop(Level world, BlockPos pos) {
-		return world.getBlockState(pos) == this.blockState;
+		// Neighbour updates can change directional block-state properties after the
+		// crop was queued. It is still the same crop as long as the block matches.
+		return world.getBlockState(pos).is(this.blockState.getBlock());
 	}
 
 	@Override

--- a/src/main/java/forestry/arboriculture/trees/TreeItem.java
+++ b/src/main/java/forestry/arboriculture/trees/TreeItem.java
@@ -104,10 +104,10 @@ public class TreeItem extends ItemGE implements IVariableFermentable, IColoredIt
 		// x, y, z are the coordinates of the block "hit", can thus either be the soil or tall grass, etc.
 		BlockState hitBlock = worldIn.getBlockState(pos);
 		if (!hitBlock.canBeReplaced(context)) {
-			if (!worldIn.isEmptyBlock(pos.above())) {
+			pos = context.getClickedPos();
+			if (!worldIn.getBlockState(pos).canBeReplaced(context)) {
 				return InteractionResultHolder.pass(stack);
 			}
-			pos = pos.above(); //TODO: Change this so saplings aren't placed on top of a block when clicking the side
 		}
 
 		if (tree.canStay(worldIn, pos)) {


### PR DESCRIPTION
Route harvested chorus flowers through NeoForges modern blockdrop handling so drop events can modify or cancel the spawned item entities. The farm returns no direct harvested stack, preventing duplicate output while allowing the spawned flower to be collected through the existing germling collection path.

Queue chorus stems using their actual block state instead of the default chorus plant state. Chorus stems contain directional connection properties that differ from the default state.

Validate queued CropDestroy entries by block type rather than exact block-state identity. Removing neighboring chorus stems can update their directional properties before they are processed, which previously invalidated queued crops and left dead stems in the farm indefinitely.

Also allow an empty flower position to continue traversal from a chorus stem directly below, so the remaining plant structure can be revisited after the terminal flower has been harvested.