### PR TITLE
fix: restore sniffer fossil drops

### DIFF
--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -97,7 +97,7 @@ public class ModuleApiculture extends BlankForestryModule {
 	}
 
 	private static void modifySnifferLoot(LootTableLoadEvent event) {
-		if (event.getName().equals(BuiltInLootTables.SNIFFER_DIGGING)) {
+		if (event.getKey().equals(BuiltInLootTables.SNIFFER_DIGGING)) {
 			LootPool main = event.getTable().getPool("main");
 
 			if (main != null) {

--- a/src/main/java/forestry/arboriculture/ModuleArboriculture.java
+++ b/src/main/java/forestry/arboriculture/ModuleArboriculture.java
@@ -72,7 +72,7 @@ public class ModuleArboriculture extends BlankForestryModule {
 	}
 
 	private static void modifySnifferLoot(LootTableLoadEvent event) {
-		if (event.getName().equals(BuiltInLootTables.SNIFFER_DIGGING)) {
+		if (event.getKey().equals(BuiltInLootTables.SNIFFER_DIGGING)) {
 			LootPool main = event.getTable().getPool("main");
 
 			if (main != null) {


### PR DESCRIPTION
Compare the Sniffer digging loot table using its ResourceKey so Forestry's amber drone and sapling fossils are actually added in 1.21.1.