### PR TITLE
fix: require full ripeness before harvesting fruit

### DIFF
--- a/src/farms/java/forestry/agriculture/farmlogic/FarmLogicOrchard.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/FarmLogicOrchard.java
@@ -123,7 +123,7 @@ public class FarmLogicOrchard extends FarmLogic {
 		IFruitBearer fruitBearer = TileUtil.getTile(world, position, IFruitBearer.class);
 
 		if (fruitBearer != null) {
-			if (fruitBearer.hasFruit() && fruitBearer.getRipeness() >= 0.9f) {
+			if (fruitBearer.hasFruit() && fruitBearer.getRipeness() >= 1.0f) {
 				return new CropFruit(world, position);
 			}
 		} else {

--- a/src/farms/java/forestry/agriculture/farmlogic/crops/CropFruit.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/crops/CropFruit.java
@@ -18,7 +18,7 @@ public class CropFruit extends Crop {
 	@Override
 	protected boolean isCrop(Level world, BlockPos pos) {
 		IFruitBearer bearer = TileUtil.getTile(world, pos, IFruitBearer.class);
-		return bearer != null && bearer.hasFruit() && bearer.getRipeness() >= 0.9f;
+		return bearer != null && bearer.hasFruit() && bearer.getRipeness() >= 1.0f;
 	}
 
 	@Override

--- a/src/main/java/forestry/arboriculture/leaves/BlockForestryLeaves.java
+++ b/src/main/java/forestry/arboriculture/leaves/BlockForestryLeaves.java
@@ -104,7 +104,7 @@ public class BlockForestryLeaves extends BlockAbstractLeaves implements Bonemeal
 			ItemStack heldItem = player.getItemInHand(hand);
 			ItemStack otherHand = player.getItemInHand(hand == InteractionHand.MAIN_HAND ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND);
 			if (heldItem.isEmpty() && otherHand.isEmpty()) {
-				if (leaves.hasFruit() && leaves.getRipeness() >= 0.9F) {
+				if (leaves.hasFruit() && leaves.getRipeness() >= 1.0F) {
 					BlockUtil.sendDestroyEffects(level, pos, state);
 					for (ItemStack fruit : leaves.pickFruit(ItemStack.EMPTY)) {
 						ItemHandlerHelper.giveItemToPlayer(player, fruit);


### PR DESCRIPTION
Raise fruit harvest thresholds from 90% to 100% for manual leaf harvesting and orchard/multifarm logic.

This prevents partially ripened fruit from being harvested and reset before Fruit#getFruits considers it mature enough to produce drops.