### PR TITLE
fix: publish split Forestry modules to Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -876,6 +876,22 @@ publishing {
 				artifact javadocJar
 				artifact apiJar
 			}
+
+			contentModules.each { m ->
+				create("maven${m.capitalize()}", MavenPublication) {
+					groupId = project.group
+					artifactId = "forestry${m}-${minecraftVersion}"
+					version = project.version
+					artifact contentJars[m]
+
+					pom.withXml {
+						var dependency = asNode().appendNode('dependencies').appendNode('dependency')
+						dependency.appendNode('groupId', project.group)
+						dependency.appendNode('artifactId', project.base.archivesName.get())
+						dependency.appendNode('version', project.version)
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Publish the Butterflies, Farms, and Mail split modules as separate Maven artifacts. Add an exact-version dependency from each optional module to Forestry core while keeping the core artifact independent of the split modules.