### PR TITLE
fix: dispatch all centrifuge outputs

### DIFF
--- a/src/main/java/forestry/core/content/machines/tiles/TileCentrifuge.java
+++ b/src/main/java/forestry/core/content/machines/tiles/TileCentrifuge.java
@@ -103,13 +103,9 @@ public class TileCentrifuge extends TilePowered implements ISocketable, WorldlyC
 
 	@Override
 	public boolean workCycle() {
-		if (tryAddPending()) {
-			return true;
-		}
-
 		if (!this.pendingProducts.isEmpty()) {
-			this.craftPreviewInventory.setItem(0, ItemStack.EMPTY);
-			return false;
+			tryAddPending();
+			return this.pendingProducts.isEmpty();
 		}
 
 		if (this.currentRecipe == null) {
@@ -126,7 +122,8 @@ public class TileCentrifuge extends TilePowered implements ISocketable, WorldlyC
 		this.craftPreviewInventory.setItem(0, previewStack);
 
 		getInternalInventory().removeItem(InventoryCentrifuge.SLOT_RESOURCE, 1);
-		return true;
+		tryAddPending();
+		return this.pendingProducts.isEmpty();
 	}
 
 	private void checkRecipe() {


### PR DESCRIPTION
keeps all centrifuge outputs in the same processing cycle until theyve all been inserted.

fixes secondary outputs taking another full cycle and makes multi-output recipes + amber electron tube bonuses work properly.

fixes #370