### PR TITLE
fix: add Hero of the Village gifts

### DIFF
--- a/src/generated/resources/data/forestry/loot_table/gameplay/hero_of_the_village/arborist_gift.json
+++ b/src/generated/resources/data/forestry/loot_table/gameplay/hero_of_the_village/arborist_gift.json
@@ -1,0 +1,34 @@
+{
+  "type": "minecraft:gift",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:tag",
+          "expand": true,
+          "functions": [
+            {
+              "add": false,
+              "count": {
+                "type": "minecraft:uniform",
+                "max": 4.0,
+                "min": 1.0
+              },
+              "function": "minecraft:set_count"
+            }
+          ],
+          "name": "forestry:forestry_fruits"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "forestry:proven_grafter",
+          "weight": 4
+        }
+      ],
+      "name": "forestry_arborist_gift",
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "forestry:gameplay/hero_of_the_village/arborist_gift"
+}

--- a/src/generated/resources/data/forestry/loot_table/gameplay/hero_of_the_village/beekeeper_gift.json
+++ b/src/generated/resources/data/forestry/loot_table/gameplay/hero_of_the_village/beekeeper_gift.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:gift",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:tag",
+          "expand": true,
+          "functions": [
+            {
+              "add": false,
+              "count": {
+                "type": "minecraft:uniform",
+                "max": 4.0,
+                "min": 1.0
+              },
+              "function": "minecraft:set_count"
+            }
+          ],
+          "name": "forestry:village_combs"
+        },
+        {
+          "type": "minecraft:tag",
+          "expand": true,
+          "name": "forestry:scoops",
+          "weight": 5
+        }
+      ],
+      "name": "forestry_beekeeper_gift",
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "forestry:gameplay/hero_of_the_village/beekeeper_gift"
+}

--- a/src/generated/resources/data/neoforge/data_maps/villager_profession/raid_hero_gifts.json
+++ b/src/generated/resources/data/neoforge/data_maps/villager_profession/raid_hero_gifts.json
@@ -1,0 +1,10 @@
+{
+  "values": {
+    "forestry:arborist": {
+      "loot_table": "forestry:gameplay/hero_of_the_village/arborist_gift"
+    },
+    "forestry:beekeeper": {
+      "loot_table": "forestry:gameplay/hero_of_the_village/beekeeper_gift"
+    }
+  }
+}

--- a/src/main/java/forestry/core/data/ForestryDataMapProvider.java
+++ b/src/main/java/forestry/core/data/ForestryDataMapProvider.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
+import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
@@ -13,7 +14,9 @@ import net.neoforged.neoforge.common.data.DataMapProvider;
 import net.neoforged.neoforge.registries.datamaps.builtin.Compostable;
 import net.neoforged.neoforge.registries.datamaps.builtin.FurnaceFuel;
 import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
+import net.neoforged.neoforge.registries.datamaps.builtin.RaidHeroGift;
 
+import forestry.api.ForestryConstants;
 import forestry.apiculture.features.ApicultureItems;
 import forestry.apiculture.bees.ItemPollenCluster;
 import forestry.arboriculture.features.ArboricultureBlocks;
@@ -24,12 +27,13 @@ import forestry.core.platform.item.ItemFruit;
 import forestry.core.content.resources.EnumCraftingMaterial;
 
 /**
- * Generates the NeoForge built-in data maps for Forestry items:
+ * Generates the NeoForge built-in data maps for Forestry items and villagers:
  * <ul>
  *     <li>{@code neoforge:compostables} - composter chances (replaces the old imperative
  *     {@code ComposterBlock.COMPOSTABLES} mutation)</li>
  *     <li>{@code neoforge:furnace_fuels} - burn times for peat, charcoal and log piles (replacing the
  *     old per-item {@code ItemProperties.burnTime}), so they work in vanilla furnaces, Create blaze burners, etc.</li>
+ *     <li>{@code neoforge:raid_hero_gifts} - Hero of the Village gifts for Forestry professions.</li>
  * </ul>
  */
 public class ForestryDataMapProvider extends DataMapProvider {
@@ -41,6 +45,7 @@ public class ForestryDataMapProvider extends DataMapProvider {
 	protected void gather(HolderLookup.Provider provider) {
 		gatherCompostables();
 		gatherFurnaceFuels();
+		gatherRaidHeroGifts();
 	}
 
 	private void gatherCompostables() {
@@ -65,6 +70,12 @@ public class ForestryDataMapProvider extends DataMapProvider {
 			compostable(composts, leaves, 0.3f);
 		}
 		// The cocoon entry is added by the butterflies jar, which merges into this data map from its own file
+	}
+
+	private void gatherRaidHeroGifts() {
+		Builder<RaidHeroGift, VillagerProfession> gifts = builder(NeoForgeDataMaps.RAID_HERO_GIFTS);
+		gifts.add(ForestryConstants.forestry("beekeeper"), new RaidHeroGift(ForestryGiftLootTables.BEEKEEPER_GIFT), false);
+		gifts.add(ForestryConstants.forestry("arborist"), new RaidHeroGift(ForestryGiftLootTables.ARBORIST_GIFT), false);
 	}
 
 	private void gatherFurnaceFuels() {

--- a/src/main/java/forestry/core/data/ForestryGiftLootTables.java
+++ b/src/main/java/forestry/core/data/ForestryGiftLootTables.java
@@ -1,0 +1,45 @@
+package forestry.core.data;
+
+import forestry.api.ForestryConstants;
+import forestry.api.ForestryTags;
+import forestry.arboriculture.features.ArboricultureItems;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.loot.LootTableSubProvider;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.entries.TagEntry;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+
+import java.util.function.BiConsumer;
+
+public class ForestryGiftLootTables implements LootTableSubProvider {
+	public static final ResourceKey<LootTable> BEEKEEPER_GIFT = ResourceKey.create(Registries.LOOT_TABLE, ForestryConstants.forestry("gameplay/hero_of_the_village/beekeeper_gift"));
+	public static final ResourceKey<LootTable> ARBORIST_GIFT = ResourceKey.create(Registries.LOOT_TABLE, ForestryConstants.forestry("gameplay/hero_of_the_village/arborist_gift"));
+
+	public ForestryGiftLootTables(HolderLookup.Provider registries) {
+	}
+
+	@Override
+	public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
+		consumer.accept(BEEKEEPER_GIFT, LootTable.lootTable().withPool(LootPool.lootPool()
+			.name("forestry_beekeeper_gift")
+			.setRolls(ConstantValue.exactly(1))
+			.add(TagEntry.expandTag(ForestryTags.Items.VILLAGE_COMBS)
+				.apply(SetItemCountFunction.setCount(UniformGenerator.between(1, 4))))
+			.add(TagEntry.expandTag(ForestryTags.Items.SCOOPS).setWeight(5))
+		));
+
+		consumer.accept(ARBORIST_GIFT, LootTable.lootTable().withPool(LootPool.lootPool()
+			.name("forestry_arborist_gift")
+			.setRolls(ConstantValue.exactly(1))
+			.add(TagEntry.expandTag(ForestryTags.Items.FORESTRY_FRUITS)
+				.apply(SetItemCountFunction.setCount(UniformGenerator.between(1, 4))))
+			.add(LootItem.lootTableItem(ArboricultureItems.PROVEN_GRAFTER.item()).setWeight(4))
+		));
+	}
+}

--- a/src/main/java/forestry/core/data/ForestryLootTableProvider.java
+++ b/src/main/java/forestry/core/data/ForestryLootTableProvider.java
@@ -19,7 +19,8 @@ public class ForestryLootTableProvider extends LootTableProvider {
 	public ForestryLootTableProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, Set<ResourceLocation> contentOwned) {
 		super(output, Set.of(), List.of(
 			new SubProviderEntry(registries -> new ForestryBlockLootTables(registries, contentOwned), LootContextParamSets.BLOCK),
-			new SubProviderEntry(ForestryChestLootTables::new, LootContextParamSets.CHEST)
+			new SubProviderEntry(ForestryChestLootTables::new, LootContextParamSets.CHEST),
+			new SubProviderEntry(ForestryGiftLootTables::new, LootContextParamSets.GIFT)
 		), lookupProvider);
 	}
 }


### PR DESCRIPTION
assign forestry beekeepers and arborists dedicated raid hero gift loot tables through neoforges raid hero gift data map.

makes the beekeeper villager drop 1-4 random combs or a random "scoop" tag item and the arborist village 1-4 random forestry_fruits tag items or a proven_grafter

fixes #375