### PR TITLE
feat: support third-party saplings

### DIFF
--- a/src/farms/java/forestry/agriculture/farmlogic/FarmLogicArboreal.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/FarmLogicArboreal.java
@@ -1,11 +1,14 @@
 package forestry.agriculture.farmlogic;
 
+import com.google.common.collect.ImmutableSet;
 import forestry.api.agriculture.ICrop;
 import forestry.api.agriculture.IFarmHousing;
 import forestry.api.agriculture.IFarmType;
 import forestry.api.agriculture.IFarmable;
+import forestry.agriculture.farmlogic.farmables.FarmableSapling;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -116,6 +119,16 @@ public class FarmLogicArboreal extends FarmLogicHomogeneous {
 		Collections.shuffle(getFarmables());
 		for (IFarmable candidate : getFarmables()) {
 			if (farmHousing.plantGermling(candidate, world, position, direction)) {
+				return true;
+			}
+		}
+
+		var germlings = farmHousing.getFarmInventory().getGermlingsInventory();
+		for (int i = 0; i < germlings.getContainerSize(); i++) {
+			ItemStack stack = germlings.getItem(i);
+			if (stack.is(ItemTags.SAPLINGS)
+				&& getFarmables().stream().noneMatch(farmable -> farmable.isGermling(stack))
+				&& farmHousing.plantGermling(new FarmableSapling(stack.getItem(), ImmutableSet.of()), world, position, direction)) {
 				return true;
 			}
 		}

--- a/src/farms/java/forestry/agriculture/farmlogic/FarmType.java
+++ b/src/farms/java/forestry/agriculture/farmlogic/FarmType.java
@@ -6,6 +6,7 @@ import forestry.api.agriculture.*;
 import net.minecraft.Util;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -103,7 +104,7 @@ public final class FarmType implements IFarmType {
 				return true;
 			}
 		}
-		return false;
+		return this.id.equals(ForestryFarmTypes.ARBOREAL) && stack.is(ItemTags.SAPLINGS);
 	}
 
 	@Override


### PR DESCRIPTION
Allow arboreal farms to accept saplings from the vanilla saplings tag and fall back to normal item placement when no registered farmable handles them.

closes #354 